### PR TITLE
fix(payment_executor): read commitments from salary contract

### DIFF
--- a/PR_DESCRIPTION_58.md
+++ b/PR_DESCRIPTION_58.md
@@ -1,0 +1,13 @@
+Closes #58
+
+## Changes
+- Fixed `payment_executor` to read employee commitments from the dedicated `salary_commitment` contract instead of `payroll_registry`.
+- Kept `payroll_registry` as the source for company metadata and admin authorization.
+- Added the missing `salary_commitment` dependency to `payment_executor` so the contract builds with the new client import.
+
+## Why
+The executor already accepted a commitment contract address in its config, but it was never used. That meant the proof input was sourced from the wrong contract, which did not match the intended architecture and could lead to inconsistent payroll verification behavior.
+
+## Testing
+- I verified the code changes by inspection and updated the contract wiring accordingly.
+- I could not run `cargo test` in this workspace because Rust tooling is not available on the current PATH.

--- a/contracts/payment_executor/Cargo.toml
+++ b/contracts/payment_executor/Cargo.toml
@@ -13,10 +13,12 @@ soroban-sdk = { workspace = true }
 soroban-token-sdk = { workspace = true }
 payroll_registry = { path = "../payroll_registry" }
 proof_verifier = { path = "../proof_verifier" }
+salary_commitment = { path = "../salary_commitment" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 payroll_registry = { path = "../payroll_registry" }
+salary_commitment = { path = "../salary_commitment" }
 token = { path = "../token" }
 
 [features]

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -250,17 +250,19 @@ mod tests {
     use ::token::{Token, TokenClient};
     use payroll_registry::PayrollRegistry;
     use proof_verifier::{ProofVerifier, VerificationKey};
+    use salary_commitment::SalaryCommitmentContract;
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::Env;
 
     fn setup_addresses(env: &Env) -> ContractAddresses {
         let registry_id = env.register_contract(None, PayrollRegistry);
+        let commitment_id = env.register_contract(None, SalaryCommitmentContract);
         let verifier_id = env.register_contract(None, ProofVerifier);
         let token_id = env.register_contract(None, Token);
 
         ContractAddresses {
             registry: registry_id,
-            commitment: Address::generate(env),
+            commitment: commitment_id,
             verifier: verifier_id,
             token: token_id,
         }
@@ -321,6 +323,7 @@ mod tests {
         let verifier_client = ProofVerifierClient::new(&env, &addresses.verifier);
         verifier_client.initialize_verifier(&mock_vk(&env));
 
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
         let token_client = TokenClient::new(&env, &addresses.token);
 
@@ -330,6 +333,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[9u8; 32]);
 
         let company_id = registry_client.register_company(&admin, &treasury);
+        commitment_client.store_commitment(&employee, &commitment);
         registry_client.add_employee(&company_id, &employee, &commitment);
 
         token_client.mint(&treasury, &10_000);
@@ -367,6 +371,7 @@ mod tests {
         let verifier_client = ProofVerifierClient::new(&env, &addresses.verifier);
         verifier_client.initialize_verifier(&mock_vk(&env));
 
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
         let token_client = TokenClient::new(&env, &addresses.token);
 
@@ -376,6 +381,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[7u8; 32]);
 
         let company_id = registry_client.register_company(&admin, &treasury);
+        commitment_client.store_commitment(&employee, &commitment);
         registry_client.add_employee(&company_id, &employee, &commitment);
         token_client.mint(&treasury, &10_000);
 
@@ -469,6 +475,7 @@ mod tests {
         let verifier_client = ProofVerifierClient::new(&env, &addresses.verifier);
         verifier_client.initialize_verifier(&mock_vk(&env));
 
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
         let token_client = TokenClient::new(&env, &addresses.token);
 
@@ -478,6 +485,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[8u8; 32]);
 
         let company_id = registry_client.register_company(&admin, &treasury);
+        commitment_client.store_commitment(&employee, &commitment);
         registry_client.add_employee(&company_id, &employee, &commitment);
         token_client.mint(&treasury, &10_000);
 

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -2,6 +2,7 @@
 
 use payroll_registry::{CompanyInfo, PayrollRegistryClient};
 use proof_verifier::{Groth16Proof, ProofVerifierClient};
+use salary_commitment::SalaryCommitmentContractClient;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env,
 };
@@ -106,9 +107,11 @@ impl PaymentExecutor {
             return Err(PaymentError::AlreadyPaid);
         }
 
-        // Read on-chain commitment and company metadata from payroll_registry.
+        // Read the employee commitment from the dedicated commitment contract
+        // and company metadata from payroll_registry.
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
+        let commitment = commitment_client.get_commitment(&employee).commitment;
         let registry = PayrollRegistryClient::new(&env, &addresses.registry);
-        let on_chain_commitment = registry.get_commitment(&company_id, &employee);
         let company: CompanyInfo = registry.get_company(&company_id);
 
         // Ensure only HR admin for this company can trigger payroll.
@@ -117,7 +120,7 @@ impl PaymentExecutor {
         // Construct public inputs required by issue #20:
         // input[0] = on-chain commitment, input[1] = caller-provided amount.
         let mut public_inputs = soroban_sdk::Vec::new(&env);
-        public_inputs.push_back(on_chain_commitment);
+        public_inputs.push_back(commitment);
         public_inputs.push_back(Self::amount_to_public_input(&env, amount));
 
         // Validate Groth16 proof via proof_verifier contract.

--- a/contracts/payment_executor/tests/security_tests.rs
+++ b/contracts/payment_executor/tests/security_tests.rs
@@ -2,6 +2,7 @@ use ::token::{Token, TokenClient};
 use payment_executor::{ContractAddresses, PaymentError, PaymentExecutor, PaymentExecutorClient};
 use payroll_registry::{PayrollRegistry, PayrollRegistryClient};
 use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
+use salary_commitment::SalaryCommitmentContract;
 use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
 use soroban_sdk::{Address, BytesN, Env, IntoVal, Vec};
 
@@ -27,6 +28,7 @@ fn setup_system<'a>(
 ) -> (
     PaymentExecutorClient<'a>,
     PayrollRegistryClient<'a>,
+    salary_commitment::SalaryCommitmentContractClient<'a>,
     TokenClient<'a>,
     u64,
     Address,
@@ -36,17 +38,19 @@ fn setup_system<'a>(
 
     let executor_id = env.register_contract(None, PaymentExecutor);
     let registry_id = env.register_contract(None, PayrollRegistry);
+    let commitment_id = env.register_contract(None, SalaryCommitmentContract);
     let verifier_id = env.register_contract(None, ProofVerifier);
     let token_id = env.register_contract(None, Token);
 
     let executor = PaymentExecutorClient::new(env, &executor_id);
     let registry = PayrollRegistryClient::new(env, &registry_id);
+    let commitment_client = salary_commitment::SalaryCommitmentContractClient::new(env, &commitment_id);
     let verifier = ProofVerifierClient::new(env, &verifier_id);
     let token = TokenClient::new(env, &token_id);
 
     let addresses = ContractAddresses {
         registry: registry_id,
-        commitment: Address::generate(env),
+        commitment: commitment_id,
         verifier: verifier_id,
         token: token_id,
     };
@@ -61,7 +65,7 @@ fn setup_system<'a>(
 
     token.mint(&treasury, &100_000);
 
-    (executor, registry, token, company_id, admin, treasury)
+    (executor, registry, commitment_client, token, company_id, admin, treasury)
 }
 
 /// Acceptance Criteria: Proof Replay Protection (Double Spend)
@@ -71,10 +75,11 @@ fn setup_system<'a>(
 #[test]
 fn test_proof_replay_protection() {
     let env = Env::default();
-    let (executor, registry, _token, company_id, _admin, _treasury) = setup_system(&env);
+    let (executor, registry, commitment_client, _token, company_id, _admin, _treasury) = setup_system(&env);
 
     let employee = Address::generate(&env);
     let commitment = BytesN::from_array(&env, &[9u8; 32]);
+    commitment_client.store_commitment(&employee, &commitment);
     registry.add_employee(&company_id, &employee, &commitment);
 
     let proof_a = BytesN::from_array(&env, &[1u8; 64]);
@@ -156,10 +161,11 @@ fn test_authorization_add_employee_fails_for_non_admin() {
 #[test]
 fn test_reentrancy_state_updates_before_external_calls() {
     let env = Env::default();
-    let (executor, registry, _token, company_id, _admin, _treasury) = setup_system(&env);
+    let (executor, registry, commitment_client, _token, company_id, _admin, _treasury) = setup_system(&env);
 
     let employee = Address::generate(&env);
     let commitment = BytesN::from_array(&env, &[9u8; 32]);
+    commitment_client.store_commitment(&employee, &commitment);
     registry.add_employee(&company_id, &employee, &commitment);
 
     let proof_a = BytesN::from_array(&env, &[5u8; 64]);


### PR DESCRIPTION
Closes #58

## Changes
- Fixed `payment_executor` to read employee commitments from the dedicated `salary_commitment` contract instead of `payroll_registry`.
- Kept `payroll_registry` as the source for company metadata and admin authorization.
- Added the missing `salary_commitment` dependency to `payment_executor` so the contract builds with the new client import.

## Why
The executor already accepted a commitment contract address in its config, but it was never used. That meant the proof input was sourced from the wrong contract, which did not match the intended architecture and could lead to inconsistent payroll verification behavior.

## Testing
- I verified the code changes by inspection and updated the contract wiring accordingly.
- I could not run `cargo test` in this workspace because Rust tooling is not available on the current PATH.