### PR TITLE
test: add fuzz target for proof inputs and batch validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 resolver = "2"
 members = ["contracts/*", "cli"]
+exclude = ["fuzz"]
+
 
 [workspace.package]
 version = "0.1.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "zk-payroll-contracts-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+libfuzzer-sys = { version = "0.4", features = ["arbitrary"] }
+arbitrary = { version = "1.3", features = ["derive"] }
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+payment_executor = { path = "../contracts/payment_executor", features = ["testutils"] }
+payroll_registry = { path = "../contracts/payroll_registry", features = ["testutils"] }
+proof_verifier = { path = "../contracts/proof_verifier", features = ["testutils"] }
+token = { path = "../contracts/token" }
+
+# Prevent this crate from ruining workspaces
+[workspace]
+
+[[bin]]
+name = "fuzz_proof_validation"
+path = "fuzz_targets/fuzz_proof_validation.rs"
+test = false
+doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,96 @@
+# Fuzz Testing
+
+This directory contains fuzz tests for proof validation, single payments, and batch payments in the zk-payroll contracts.
+
+Fuzzing is implemented using `cargo-fuzz` (libFuzzer).
+
+## Prerequisites
+
+1. **Rust Nightly**: `cargo-fuzz` requires a nightly Rust compiler.
+   ```bash
+   rustup toolchain install nightly
+   ```
+
+2. **cargo-fuzz**: Install the `cargo-fuzz` CLI tool.
+   ```bash
+   cargo install cargo-fuzz
+   ```
+
+3. **C/C++ Compiler**: A modern compiler (such as `clang` or `gcc` on Linux/macOS, or MSVC on Windows) is needed for compiling sanitizer instrumentation. Note: libFuzzer has native support on Unix-like environments; running on Windows might require WSL2 or MSVC LLVM tools.
+
+## Running the Fuzzer
+
+To run the proof and payment validation fuzzer, execute:
+
+```bash
+# Navigate to the workspace root or the fuzz directory, then run:
+cargo +nightly fuzz run fuzz_proof_validation
+```
+
+This will run the fuzzer continuously until a crash/bug (such as an unexpected panic or failed invariant assertion) is found or it is manually stopped (Ctrl+C).
+
+## Reproducing Findings Locally
+
+If the fuzzer finds a bug, it will save the offending input payload to a file under `fuzz/artifacts/fuzz_proof_validation/crash-XXXXXXXXXXXX`.
+
+To reproduce the failure locally and debug:
+
+```bash
+cargo +nightly fuzz run fuzz_proof_validation fuzz/artifacts/fuzz_proof_validation/crash-XXXXXXXXXXXX
+```
+
+You can run this with `RUST_BACKTRACE=1` to print the backtrace of the crash:
+
+```bash
+$env:RUST_BACKTRACE=1   # On Windows PowerShell
+# OR
+export RUST_BACKTRACE=1 # On Linux/macOS
+
+cargo +nightly fuzz run fuzz_proof_validation fuzz/artifacts/fuzz_proof_validation/crash-XXXXXXXXXXXX
+```
+
+## CI/CD Integration Guidance
+
+Since fuzz testing runs indefinitely, running continuous fuzzing directly in PR check pipelines can be slow and expensive. Below are the recommended approaches for CI integration:
+
+### Option A: Regression testing (Recommended for PRs)
+Execute the fuzz target with a time limit (e.g., 60 seconds) or run only existing regression inputs (artifacts) on every pull request.
+
+To run with a time limit of 1 minute in CI:
+```bash
+cargo +nightly fuzz run fuzz_proof_validation -- -max_total_time=60
+```
+
+To run with zero new fuzz inputs (just runs existing corpus/regression files):
+```bash
+cargo +nightly fuzz run fuzz_proof_validation -- -runs=0
+```
+
+### Option B: Nightly Scheduled Fuzzing
+Set up a scheduled GitHub Action that runs the fuzzer for a longer duration (e.g., 10 minutes or 1 hour) every night:
+
+```yaml
+name: Nightly Fuzz Testing
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every night at 2 AM
+  workflow_dispatch:
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Run Fuzzer
+        run: |
+          cd fuzz
+          cargo +nightly fuzz run fuzz_proof_validation -- -max_total_time=600
+```

--- a/fuzz/fuzz_targets/fuzz_proof_validation.rs
+++ b/fuzz/fuzz_targets/fuzz_proof_validation.rs
@@ -1,0 +1,455 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use arbitrary::Arbitrary;
+
+use soroban_sdk::{
+    Address, BytesN, Env, Vec, testutils::Address as _,
+};
+use payment_executor::{
+    ContractAddresses, PaymentExecutor, PaymentExecutorClient, PaymentError,
+};
+use payroll_registry::{PayrollRegistry, PayrollRegistryClient};
+use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey, Groth16Proof};
+use token::{Token, TokenClient};
+
+#[derive(Arbitrary, Debug)]
+pub struct FuzzInput {
+    pub action: FuzzAction,
+}
+
+#[derive(Arbitrary, Debug)]
+pub enum FuzzAction {
+    VerifyDirect {
+        proof_a: [u8; 64],
+        proof_b: [u8; 128],
+        proof_c: [u8; 64],
+        public_inputs: std::vec::Vec<[u8; 32]>,
+        vk_alpha: [u8; 64],
+        vk_beta: [u8; 128],
+        vk_gamma: [u8; 128],
+        vk_delta: [u8; 128],
+        vk_ic: std::vec::Vec<[u8; 64]>,
+    },
+    VerifyPaymentProofDirect {
+        proof_bytes: [u8; 256],
+        public_inputs: std::vec::Vec<[u8; 32]>,
+        vk_alpha: [u8; 64],
+        vk_beta: [u8; 128],
+        vk_gamma: [u8; 128],
+        vk_delta: [u8; 128],
+        vk_ic: std::vec::Vec<[u8; 64]>,
+    },
+    ExecutePayment {
+        amount: i128,
+        proof_a: [u8; 64],
+        proof_b: [u8; 128],
+        proof_c: [u8; 64],
+        nullifier: [u8; 32],
+        period: u32,
+        commitment: [u8; 32],
+        use_valid_inputs: bool,
+    },
+    ExecuteBatchPayroll {
+        amounts: std::vec::Vec<i128>,
+        proofs_a: std::vec::Vec<[u8; 64]>,
+        proofs_b: std::vec::Vec<[u8; 128]>,
+        proofs_c: std::vec::Vec<[u8; 64]>,
+        nullifiers: std::vec::Vec<[u8; 32]>,
+        commitments: std::vec::Vec<[u8; 32]>,
+        period: u32,
+        force_duplicate_nullifier: bool,
+        force_empty_batch: bool,
+        force_mismatched_length: bool,
+    },
+}
+
+fn mock_vk(env: &Env) -> VerificationKey {
+    VerificationKey {
+        alpha: BytesN::from_array(env, &[0u8; 64]),
+        beta: BytesN::from_array(env, &[0u8; 128]),
+        gamma: BytesN::from_array(env, &[0u8; 128]),
+        delta: BytesN::from_array(env, &[0u8; 128]),
+        ic: Vec::from_array(
+            env,
+            [
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+            ],
+        ),
+    }
+}
+
+struct TestSystem<'a> {
+    env: Env,
+    executor: PaymentExecutorClient<'a>,
+    registry: PayrollRegistryClient<'a>,
+    verifier: ProofVerifierClient<'a>,
+    token: TokenClient<'a>,
+    company_id: u64,
+    admin: Address,
+    treasury: Address,
+}
+
+fn setup_system(env: &Env) -> TestSystem {
+    env.mock_all_auths();
+
+    let executor_id = env.register_contract(None, PaymentExecutor);
+    let registry_id = env.register_contract(None, PayrollRegistry);
+    let verifier_id = env.register_contract(None, ProofVerifier);
+    let token_id = env.register_contract(None, Token);
+
+    let executor = PaymentExecutorClient::new(env, &executor_id);
+    let registry = PayrollRegistryClient::new(env, &registry_id);
+    let verifier = ProofVerifierClient::new(env, &verifier_id);
+    let token = TokenClient::new(env, &token_id);
+
+    let addresses = ContractAddresses {
+        registry: registry_id,
+        commitment: Address::generate(env),
+        verifier: verifier_id,
+        token: token_id,
+    };
+
+    executor.initialize(&addresses);
+    verifier.init_verifier_admin(&Address::generate(env));
+    verifier.initialize_verifier(&mock_vk(env));
+
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+
+    let company_id = registry.register_company(&admin, &treasury);
+    executor.create_period(&company_id).unwrap();
+
+    token.mint(&treasury, &1_000_000);
+
+    TestSystem {
+        env: env.clone(),
+        executor,
+        registry,
+        verifier,
+        token,
+        company_id,
+        admin,
+        treasury,
+    }
+}
+
+fuzz_target!(|input: FuzzInput| {
+    match input.action {
+        FuzzAction::VerifyDirect {
+            proof_a,
+            proof_b,
+            proof_c,
+            public_inputs,
+            vk_alpha,
+            vk_beta,
+            vk_gamma,
+            vk_delta,
+            vk_ic,
+        } => {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let verifier_id = env.register_contract(None, ProofVerifier);
+            let verifier_client = ProofVerifierClient::new(&env, &verifier_id);
+            verifier_client.init_verifier_admin(&Address::generate(&env));
+
+            let vk = VerificationKey {
+                alpha: BytesN::from_array(&env, &vk_alpha),
+                beta: BytesN::from_array(&env, &vk_beta),
+                gamma: BytesN::from_array(&env, &vk_gamma),
+                delta: BytesN::from_array(&env, &vk_delta),
+                ic: {
+                    let mut vec = Vec::new(&env);
+                    // limit to avoid high CPU/memory overhead during fuzzer execution
+                    for ic_bytes in vk_ic.iter().take(10) {
+                        vec.push_back(BytesN::from_array(&env, ic_bytes));
+                    }
+                    vec
+                },
+            };
+
+            verifier_client.initialize_verifier(&vk);
+
+            let proof = Groth16Proof {
+                a: BytesN::from_array(&env, &proof_a),
+                b: BytesN::from_array(&env, &proof_b),
+                c: BytesN::from_array(&env, &proof_c),
+            };
+
+            let mut inputs = Vec::new(&env);
+            for input_bytes in public_inputs.iter().take(10) {
+                inputs.push_back(BytesN::from_array(&env, input_bytes));
+            }
+
+            let _ = verifier_client.try_verify(&proof, &inputs);
+        }
+
+        FuzzAction::VerifyPaymentProofDirect {
+            proof_bytes,
+            public_inputs,
+            vk_alpha,
+            vk_beta,
+            vk_gamma,
+            vk_delta,
+            vk_ic,
+        } => {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let verifier_id = env.register_contract(None, ProofVerifier);
+            let verifier_client = ProofVerifierClient::new(&env, &verifier_id);
+            verifier_client.init_verifier_admin(&Address::generate(&env));
+
+            let vk = VerificationKey {
+                alpha: BytesN::from_array(&env, &vk_alpha),
+                beta: BytesN::from_array(&env, &vk_beta),
+                gamma: BytesN::from_array(&env, &vk_gamma),
+                delta: BytesN::from_array(&env, &vk_delta),
+                ic: {
+                    let mut vec = Vec::new(&env);
+                    for ic_bytes in vk_ic.iter().take(10) {
+                        vec.push_back(BytesN::from_array(&env, ic_bytes));
+                    }
+                    vec
+                },
+            };
+
+            verifier_client.initialize_verifier(&vk);
+
+            let proof = BytesN::from_array(&env, &proof_bytes);
+
+            let mut inputs = Vec::new(&env);
+            for input_bytes in public_inputs.iter().take(10) {
+                inputs.push_back(BytesN::from_array(&env, input_bytes));
+            }
+
+            let _ = verifier_client.try_verify_payment_proof(&proof, &inputs);
+        }
+
+        FuzzAction::ExecutePayment {
+            amount,
+            proof_a,
+            proof_b,
+            proof_c,
+            nullifier,
+            period,
+            commitment,
+            use_valid_inputs,
+        } => {
+            let env = Env::default();
+            let sys = setup_system(&env);
+
+            let employee = Address::generate(&env);
+
+            let test_amount = if use_valid_inputs {
+                if amount == i128::MIN {
+                    1
+                } else {
+                    amount.abs().max(1)
+                }
+            } else {
+                amount
+            };
+
+            let test_period = if use_valid_inputs { 1 } else { period };
+
+            sys.registry.add_employee(
+                &sys.company_id,
+                &employee,
+                &BytesN::from_array(&env, &commitment),
+            );
+
+            let initial_treasury = sys.token.balance(&sys.treasury);
+            let initial_employee = sys.token.balance(&employee);
+
+            let res = sys.executor.try_execute_payment(
+                &sys.company_id,
+                &employee,
+                &test_amount,
+                &BytesN::from_array(&env, &proof_a),
+                &BytesN::from_array(&env, &proof_b),
+                &BytesN::from_array(&env, &proof_c),
+                &BytesN::from_array(&env, &nullifier),
+                &test_period,
+            );
+
+            if let Ok(Ok(_record)) = res {
+                // Invariant assertions on successful payment execution
+                assert!(test_amount >= 0);
+                assert_eq!(sys.token.balance(&employee), initial_employee + test_amount);
+                assert_eq!(sys.token.balance(&sys.treasury), initial_treasury - test_amount);
+                assert!(sys.executor.is_paid(&employee, &test_period));
+                assert!(sys.executor.get_total_paid(&sys.company_id) >= test_amount);
+
+                // Proof Replay Prevention Invariant: Re-submitting same nullifier must fail
+                let replay_res = sys.executor.try_execute_payment(
+                    &sys.company_id,
+                    &employee,
+                    &test_amount,
+                    &BytesN::from_array(&env, &proof_a),
+                    &BytesN::from_array(&env, &proof_b),
+                    &BytesN::from_array(&env, &proof_c),
+                    &BytesN::from_array(&env, &nullifier),
+                    &test_period,
+                );
+                assert_eq!(replay_res.unwrap_err().unwrap(), PaymentError::ProofAlreadyUsed);
+            } else {
+                // Transaction Atomicity Invariant: Check that no state / balance changed on failure
+                assert_eq!(sys.token.balance(&employee), initial_employee);
+                assert_eq!(sys.token.balance(&sys.treasury), initial_treasury);
+            }
+        }
+
+        FuzzAction::ExecuteBatchPayroll {
+            amounts,
+            proofs_a,
+            proofs_b,
+            proofs_c,
+            nullifiers,
+            commitments,
+            period,
+            force_duplicate_nullifier,
+            force_empty_batch,
+            force_mismatched_length,
+        } => {
+            let env = Env::default();
+            let sys = setup_system(&env);
+
+            let mut batch_size = if force_empty_batch {
+                0
+            } else {
+                let mut sz = amounts.len()
+                    .min(proofs_a.len())
+                    .min(proofs_b.len())
+                    .min(proofs_c.len())
+                    .min(nullifiers.len())
+                    .min(commitments.len());
+                if sz > 15 {
+                    sz = 15; // limit size to keep execution fast
+                }
+                sz
+            };
+
+            let mut test_amounts = std::vec::Vec::new();
+            let mut test_proofs_a = std::vec::Vec::new();
+            let mut test_proofs_b = std::vec::Vec::new();
+            let mut test_proofs_c = std::vec::Vec::new();
+            let mut test_nullifiers = std::vec::Vec::new();
+            let mut test_employees = std::vec::Vec::new();
+
+            for i in 0..batch_size {
+                let employee = Address::generate(&env);
+                sys.registry.add_employee(
+                    &sys.company_id,
+                    &employee,
+                    &BytesN::from_array(&env, &commitments[i]),
+                );
+                test_employees.push(employee);
+                let amt = if amounts[i] == i128::MIN {
+                    1
+                } else {
+                    amounts[i].abs().max(1)
+                };
+                test_amounts.push(amt);
+                test_proofs_a.push(BytesN::from_array(&env, &proofs_a[i]));
+                test_proofs_b.push(BytesN::from_array(&env, &proofs_b[i]));
+                test_proofs_c.push(BytesN::from_array(&env, &proofs_c[i]));
+                test_nullifiers.push(BytesN::from_array(&env, &nullifiers[i]));
+            }
+
+            if force_duplicate_nullifier && batch_size >= 2 {
+                test_nullifiers[1] = test_nullifiers[0].clone();
+            }
+
+            if force_mismatched_length {
+                // Deliberately push an extra element to test error handling for length mismatches
+                test_amounts.push(100);
+            }
+
+            let mut sdk_employees = Vec::new(&env);
+            for emp in &test_employees {
+                sdk_employees.push_back(emp.clone());
+            }
+
+            let mut sdk_amounts = Vec::new(&env);
+            for amt in &test_amounts {
+                sdk_amounts.push_back(*amt);
+            }
+
+            let mut sdk_proofs_a = Vec::new(&env);
+            for p in &test_proofs_a {
+                sdk_proofs_a.push_back(p.clone());
+            }
+
+            let mut sdk_proofs_b = Vec::new(&env);
+            for p in &test_proofs_b {
+                sdk_proofs_b.push_back(p.clone());
+            }
+
+            let mut sdk_proofs_c = Vec::new(&env);
+            for p in &test_proofs_c {
+                sdk_proofs_c.push_back(p.clone());
+            }
+
+            let mut sdk_nullifiers = Vec::new(&env);
+            for n in &test_nullifiers {
+                sdk_nullifiers.push_back(n.clone());
+            }
+
+            let initial_treasury = sys.token.balance(&sys.treasury);
+            let mut initial_balances = std::vec::Vec::new();
+            for emp in &test_employees {
+                initial_balances.push(sys.token.balance(emp));
+            }
+
+            let res = sys.executor.try_execute_batch_payroll(
+                &sys.company_id,
+                &sdk_employees,
+                &sdk_amounts,
+                &sdk_proofs_a,
+                &sdk_proofs_b,
+                &sdk_proofs_c,
+                &sdk_nullifiers,
+                &period,
+            );
+
+            match res {
+                Ok(Ok(records)) => {
+                    // Invariant assertions on successful batch execution
+                    assert_eq!(records.len() as usize, batch_size);
+                    let mut total_expected_deduction = 0;
+                    for (i, emp) in test_employees.iter().enumerate() {
+                        assert_eq!(sys.token.balance(emp), initial_balances[i] + test_amounts[i]);
+                        total_expected_deduction += test_amounts[i];
+                    }
+                    assert_eq!(sys.token.balance(&sys.treasury), initial_treasury - total_expected_deduction);
+
+                    // Duplicate nullifier checks: if batch succeeded, then all nullifiers used must be registered
+                    for (i, emp) in test_employees.iter().enumerate() {
+                        let replay_res = sys.executor.try_execute_payment(
+                            &sys.company_id,
+                            emp,
+                            &test_amounts[i],
+                            &test_proofs_a[i],
+                            &test_proofs_b[i],
+                            &test_proofs_c[i],
+                            &test_nullifiers[i],
+                            &period,
+                        );
+                        assert_eq!(replay_res.unwrap_err().unwrap(), PaymentError::ProofAlreadyUsed);
+                    }
+                }
+                _ => {
+                    // Transaction Atomicity Invariant: If batch execution fails, no state/balance changes must persist
+                    assert_eq!(sys.token.balance(&sys.treasury), initial_treasury);
+                    for (i, emp) in test_employees.iter().enumerate() {
+                        assert_eq!(sys.token.balance(emp), initial_balances[i]);
+                    }
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
### Closes #69  

#### Summary

  This PR adds contract assurance by introducing a structured fuzzing harness for  zk-payroll-contracts  using  cargo-fuzz . The fuzzer covers proof-related inputs, edge cases, malformed commitments, empty batches,     
  and duplicate nullifiers.

  #### What Changed

  1. Workspace Exclusions: Excluded  fuzz  from the root Cargo.toml to prevent host-only sanitizer builds ( libfuzzer-sys ) from interfering with WASM compilation.
  2. Fuzz Package Setup: Created Cargo.toml defining dependencies on  libfuzzer-sys  and  arbitrary , and enabling contract crate  testutils .
  3. Fuzz Target Implementation: Created fuzz_proof_validation.rs executing fuzzed transactions under a mock Soroban environment ( Env ).                                                                                  

  4. Documentation & CI Guidance: Added README.md detailing local execution, reproduction of crashes, and CI pipelines (PR limits vs nightly schedules).

  #### Key Design Decisions

  • VM Catching of Panics: Utilized the auto-generated contract client  try_  methods (e.g.,  try_execute_payment ,  try_execute_batch_payroll ) to safely run contracts. This delegates panic containment to the
  Soroban host environment rather than crashing the fuzzer process on expected input-validation failures.
  • Invariant Assertions: Added strict post-execution assertions to guarantee:                                                                                                                                             
      • Balance Updates: Treasury and employee token balances match the payment amount precisely.
      • Proof Replay Prevention: Successful payment nullifiers are immediately checked/blocked from double spending.
      • Transaction Atomicity: Failed batch payroll executions (e.g. from duplicate nullifiers or length mismatches) result in full balance rollback/reverts.


  #### Acceptance Criteria Checklist

  [✓] Fuzz target exists for critical verification/validation paths.
  [✓] Findings are reproducible locally via the artifact command.
  [✓] CI guidance is documented for continuous fuzzing.

  #### Security Note

  All fuzzed transactions are evaluated for transaction atomicity. If a single payment in a batch fails (e.g., due to duplicate nullifiers or invalid proof), the fuzzer verifies that no partial token transfers occur    
  and the entire batch transaction is reverted.