### PR TITLE
docs: add rollback checklist, event taxonomy, contributor checklist, and client fallback guide

### DIFF
--- a/docs/contributor-module-checklist.md
+++ b/docs/contributor-module-checklist.md
@@ -1,0 +1,190 @@
+# Contributor Checklist: Adding or Expanding a Contract Module — Issue #95
+
+Use this checklist when introducing a new Soroban contract or extending an
+existing one. It covers the minimum bar for a reviewable PR. Keep it updated
+as repo standards evolve.
+
+---
+
+## 1. Interface Design
+
+- [ ] **Trait defined** — if the module exposes a public interface, define it
+  as a Rust `trait` (see `PayrollRegistryTrait` in `payroll_registry/src/lib.rs`
+  for the pattern). This makes the interface explicit and independently testable.
+
+- [ ] **Entry-point signatures reviewed** — all public entry-points have the
+  minimal parameter set needed. Avoid bundling unrelated concerns into one call.
+
+- [ ] **Error enum defined** — use a `#[contracterror]` enum with `u32`
+  discriminants instead of `panic!()` or raw strings for all recoverable error
+  conditions. Follow the `PaymentError` pattern in `payment_executor/src/lib.rs`.
+
+- [ ] **No raw `unwrap()` or `panic!()` in entry-points** — use `.expect("reason")`
+  only for truly unrecoverable invariants; use `Result` return types for everything
+  else. See the Code Standards table in [CONTRIBUTING.md](../CONTRIBUTING.md#code-standards).
+
+---
+
+## 2. Authorization
+
+- [ ] **Every state-mutating entry-point calls `env.require_auth()`** — there are
+  no exceptions. Check all `pub fn` implementations that write to storage.
+
+- [ ] **Admin role is set at init time, not hard-coded** — admin addresses are
+  passed to the initialiser and stored in `Persistent` storage. Hard-coded
+  addresses are not acceptable.
+
+- [ ] **One-time init is guarded** — the initialiser checks for an existing
+  admin/state key and panics with `"Already initialized"` if called twice.
+
+- [ ] **Role separation is explicit** — if the module introduces multiple roles
+  (e.g., admin vs. payroll operator), document them in a block comment at the
+  top of `lib.rs` following the pattern in `salary_commitment/src/lib.rs`.
+
+---
+
+## 3. Events
+
+- [ ] **All significant state changes emit an event** — at minimum: creation,
+  update, and deletion of any primary record. Pause/unpause transitions always
+  emit events.
+
+- [ ] **Event topics follow the taxonomy** — topic naming must align with
+  [docs/monitoring/event-taxonomy.md](./monitoring/event-taxonomy.md).
+  Use `PascalCase` for single-symbol topics (e.g., `"CommitmentUpdated"`);
+  use a two-symbol tuple `("contract_name", "action")` for the `payroll`
+  facade pattern.
+
+- [ ] **Event taxonomy doc updated** — add the new event(s) to
+  `docs/monitoring/event-taxonomy.md` under the appropriate category
+  (`ONB`, `FND`, `EXE`, `AUD`, `SEC`) with full field documentation.
+
+- [ ] **Payload examples updated** — if the event introduces a new data shape,
+  add a sample to [docs/payload-examples.md](./payload-examples.md).
+
+- [ ] **No sensitive values in events** — salary amounts, blinding factors, and
+  private keys must never appear in event data. Commitments (Poseidon hashes)
+  are acceptable; raw salary values are not.
+
+---
+
+## 4. Storage
+
+- [ ] **`DataKey` enum is used for all storage keys** — no inline `Symbol`
+  or string keys. Follow the `DataKey` pattern used in every existing contract.
+
+- [ ] **Storage type is appropriate** — use `Persistent` for records that must
+  survive ledger expiry (commitments, nullifiers, payment records). Use
+  `Temporary` only for short-lived nonces. Document the choice in a comment
+  if it is not obvious.
+
+- [ ] **TTL strategy documented** — if the module writes `Persistent` entries,
+  note how TTL is extended (on write, on payment execution, or via an off-chain
+  keeper). See `docs/architecture/commitment-state-storage-layout-13.md` for
+  the recommended pattern.
+
+- [ ] **Individual keys, not bulk vectors** — do not store collections of
+  records under a single key. Use per-record keys (e.g.,
+  `DataKey::Payment(employee, period)`) to avoid Soroban read/write budget
+  failures on large datasets. See the architecture doc above for rationale.
+
+---
+
+## 5. Tests
+
+- [ ] **At least one unit test per public entry-point** — happy path covered.
+  Place tests in `src/tests.rs` (for larger modules) or an inline `#[cfg(test)]`
+  module following the existing contract patterns.
+
+- [ ] **Auth rejection tested** — at least one test verifies that an
+  unauthorized caller is rejected (use `env.mock_auths` with the wrong address
+  or no auths, and assert the call panics or returns an error).
+
+- [ ] **Double-init tested** — if the module has a one-time initialiser, test
+  that calling it twice panics with `"Already initialized"`.
+
+- [ ] **Error variants tested** — for each `#[contracterror]` variant, at least
+  one test triggers that variant and asserts the correct error is returned.
+
+- [ ] **Tests pass cleanly**: `cargo test -p <crate_name>` exits with zero
+  failures before opening a PR.
+
+---
+
+## 6. Documentation
+
+- [ ] **Rustdoc on all public items** — every `pub fn`, `pub struct`, and
+  `pub enum` has a doc comment. One sentence is enough for obvious items;
+  include a note on authorization requirements and preconditions for any
+  entry-point that is not self-evident.
+
+- [ ] **Role documentation block at top of `lib.rs`** — if the module has
+  multiple roles, add a block comment explaining each role and what it is
+  allowed to do. Follow the pattern in `salary_commitment/src/lib.rs`.
+
+- [ ] **README or architecture doc linked** — if the module introduces
+  non-obvious design decisions (storage layout, cross-contract dependencies,
+  TTL policy), link or add a doc in `docs/architecture/`.
+
+- [ ] **Contributor checklist updated** — if this PR introduces a new pattern
+  or standard, update this checklist so the next contributor benefits.
+
+---
+
+## 7. Security Review
+
+- [ ] **Replay protection in place** — if the module processes proofs or
+  one-time tokens, nullifiers are recorded in `Persistent` storage *before*
+  the effect is applied (checks-effects-interactions order).
+
+- [ ] **No cross-contract reentrancy path** — review any cross-contract calls
+  (e.g., calls to `salary_commitment`, `proof_verifier`, or token contracts)
+  and confirm state writes happen before those calls where possible.
+
+- [ ] **Fuzz target considered** — if the entry-point processes variable-length
+  binary inputs (proofs, commitments), consider adding a fuzz target in
+  `fuzz/fuzz_targets/`. See `fuzz/README.md` for setup.
+
+- [ ] **Security tests in dedicated file** — for payment or proof-handling
+  modules, add a `tests/security_tests.rs` file following the pattern in
+  `contracts/payment_executor/tests/security_tests.rs`.
+
+- [ ] **`cargo audit` passes** — run `cargo audit` from the workspace root
+  before opening the PR. No new unreviewed advisories.
+
+---
+
+## 8. Release Readiness
+
+- [ ] **Deployment order documented** — if the new module has initialisation
+  dependencies on other contracts, update the deployment order in
+  [docs/ops/preflight-deployment-checklist.md](./ops/preflight-deployment-checklist.md).
+
+- [ ] **Rollback considered** — review
+  [docs/ops/rollback-checklist.md](./ops/rollback-checklist.md) and confirm
+  whether the new module introduces any state that would complicate a rollback
+  (e.g., append-only records, cross-contract pointers that callers store).
+  Document any rollback constraints in the PR description.
+
+- [ ] **WASM size within limits** — `wc -c target/wasm32-unknown-unknown/release/<crate>.wasm`
+  must be under 64 KB after `stellar contract build`.
+
+---
+
+## Related Resources
+
+| Reference | Path |
+|-----------|------|
+| CONTRIBUTING.md | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Event taxonomy | [docs/monitoring/event-taxonomy.md](./monitoring/event-taxonomy.md) |
+| Event severity mappings | [docs/monitoring/event-severity-mappings.md](./monitoring/event-severity-mappings.md) |
+| Storage layout architecture | [docs/architecture/commitment-state-storage-layout-13.md](./architecture/commitment-state-storage-layout-13.md) |
+| Preflight deployment checklist | [docs/ops/preflight-deployment-checklist.md](./ops/preflight-deployment-checklist.md) |
+| Rollback checklist | [docs/ops/rollback-checklist.md](./ops/rollback-checklist.md) |
+| Proof schema version negotiation | [docs/interop/proof-schema-version-negotiation.md](./interop/proof-schema-version-negotiation.md) |
+| Incident response playbook | [docs/incident-response-playbook.md](./incident-response-playbook.md) |
+| Fuzz targets README | [fuzz/README.md](../fuzz/README.md) |
+
+---
+
+*Closes Issue [#95](https://github.com/zkpayroll/zk-payroll-contracts/issues/95)*

--- a/docs/interop/client-fallback-behavior.md
+++ b/docs/interop/client-fallback-behavior.md
@@ -1,0 +1,216 @@
+# Client Fallback Behavior for Older Contract Interfaces — Issue #97
+
+Explains how SDK and dashboard clients should behave when they encounter a
+contract version newer than they were built against, and what the supported
+and unsupported downgrade paths are.
+
+---
+
+## Background
+
+ZK Payroll contracts evolve across three independent axes:
+
+1. **Proof schema** — the public input count and proof byte layout (governed by
+   [proof-schema-version-negotiation.md](./proof-schema-version-negotiation.md)).
+2. **Contract interface** — entry-point signatures and `#[contracttype]` struct
+   shapes.
+3. **Event shape** — topic and data fields emitted by contracts.
+
+A deployed production environment may temporarily run a contract version that is
+ahead of the client SDK or dashboard. This document defines what clients should
+do in that scenario and which combinations are safe to operate.
+
+---
+
+## Compatibility Model
+
+### Principle: No Silent Degradation
+
+Clients MUST surface interface mismatches as distinct, actionable errors rather
+than silently succeeding with incorrect behaviour. The following hard rules apply:
+
+1. **Proof schema mismatches are hard rejections.** The `proof_verifier` contract
+   returns `false` immediately when the public input count does not match the
+   stored VK. Clients must not retry with the same inputs — they must regenerate
+   the proof against the correct VK. See
+   [proof-schema-version-negotiation.md](./proof-schema-version-negotiation.md).
+
+2. **Entry-point signature changes are hard rejections.** Soroban encodes
+   arguments as XDR. Sending the wrong number or type of arguments causes a
+   transaction failure at the host level — there is no partial acceptance.
+
+3. **Event schema additions are backward compatible.** Contracts may add new
+   event fields to the `data` payload without breaking consumers that only
+   read earlier fields. However, consumers MUST NOT assume a specific data
+   length — iterate defensively.
+
+4. **Event topic renames are breaking.** If an event topic `Symbol` changes,
+   existing subscribers will stop receiving it. The taxonomy in
+   [event-taxonomy.md](../monitoring/event-taxonomy.md) is the stable contract;
+   deviations will be announced with a migration notice.
+
+---
+
+## Supported Fallback Scenarios
+
+These scenarios are safe to operate and have defined handling paths.
+
+### S1 — Old client, same proof schema, new non-breaking entry-point fields
+
+**Situation:** The contract adds optional metadata to an existing entry-point
+response struct (e.g., a new field on `PayrollRun`) but the core signature is
+unchanged.
+
+**Fallback:** The Soroban SDK deserialises known fields and ignores unknown
+trailing fields in `#[contracttype]` structs. The old client can continue
+operating. No action required.
+
+**Risk:** Low. Verify by checking the PR that introduced the new field; it should
+be appended to the struct and not inserted at a non-trailing position.
+
+---
+
+### S2 — Old client, new proof schema deployed on testnet only
+
+**Situation:** A new verifier contract with a different VK (e.g., `ic.len()` changed)
+is deployed on testnet while production still runs the old VK.
+
+**Fallback:**
+1. Read `vk.ic.len()` from the testnet verifier before generating any proofs.
+2. Use that value to configure the circuit and proof generation tooling.
+3. Do not submit testnet proofs to mainnet and vice versa — they will be rejected.
+4. See the [Client Integration Checklist](./proof-schema-version-negotiation.md#client-integration-checklist)
+   in the proof schema doc.
+
+**Risk:** Low if network environments are kept separate. The verifier hard-rejects
+mismatched inputs with no state change.
+
+---
+
+### S3 — Dashboard consuming stale event topics
+
+**Situation:** A dashboard subscribed to `"PayrollProcessed"` events from
+`payment_executor` does not yet handle the newer `"payment_executed"` topic
+from the `payroll` facade (or vice versa), resulting in incomplete display.
+
+**Fallback:**
+1. Subscribe to both topic patterns during any transition window.
+2. Normalise both event shapes to the common schema defined in
+   [event-taxonomy.md](../monitoring/event-taxonomy.md#naming-inconsistencies-known).
+3. The known naming inconsistency between the two payment paths is documented —
+   see the "Naming Inconsistencies" section in the event taxonomy doc.
+
+**Risk:** Low — duplicate events are not emitted; the two topics come from
+different contracts. Missing one path means incomplete data, not corrupted data.
+
+---
+
+### S4 — Old client, pause manager added post-deployment
+
+**Situation:** A client does not know the `pause_manager` address (it was set
+after the client was configured) and submits a batch while the system is paused.
+
+**Fallback:**
+1. The `payroll` and `payment_executor` contracts panic with `"Payroll is paused"`
+   when a pause manager is set and `is_paused()` returns `true`.
+2. Clients should catch this panic (it surfaces as a failed transaction) and
+   surface it as a distinct `PayrollPausedError` rather than a generic failure.
+3. Clients should call `pause_manager.is_paused()` before each batch submission
+   as a pre-flight check. The pause manager address should be discoverable via
+   the operator's configuration endpoint.
+
+**Risk:** Medium — a client unaware of the pause state will generate failed
+transactions that consume fees. Build the pre-flight check.
+
+---
+
+## Unsupported Downgrade Paths
+
+The following scenarios are explicitly unsupported. Clients or operators attempting
+these paths will encounter hard failures that cannot be resolved without engineering
+intervention.
+
+| Scenario | Why it is unsupported | Recommended action |
+|----------|-----------------------|-------------------|
+| **Submitting v0 proofs (3 public inputs) to a v1 verifier** | VK `ic.len()` mismatch; `verify_payment_proof` returns `false` immediately | Regenerate proofs against the v1 circuit; see proof schema doc |
+| **Calling `initialize_verifier` a second time on an existing verifier** | Contract panics with `"Verifier already initialized"` | Deploy a new `proof_verifier` instance; no in-place re-init |
+| **Calling `initialize` on `payroll` or `payment_executor` a second time** | Contracts panic with `"Already initialized"` | Contracts are single-init; a new deployment is required for address changes |
+| **Routing payments to a period that has been closed** | `payment_executor` returns `PaymentError::PeriodClosed (5)` | Open a new period; closed periods are immutable |
+| **Reading a `PayrollRun` by a run_id that was never written** | `payroll` panics with `"Run not found"` | Run IDs are contiguous starting at 1; query `RunCounter` to find the valid range |
+| **Using a revoked salary commitment for proof generation** | `salary_commitment.is_commitment_active()` returns `false`; on-chain proof will fail | Fetch the current active commitment via `get_commitment` before generating proofs |
+| **Submitting a proof with an already-used nullifier** | `payment_executor` returns `PaymentError::ProofAlreadyUsed (1)` or `salary_commitment` panics with `"Nullifier already used"` | Generate a fresh proof with a new nullifier; do not reuse nullifiers |
+
+---
+
+## Migration Planning Guide
+
+When a new contract interface or proof schema version is being rolled out, client
+teams should plan their upgrade using the following steps.
+
+### Before the upgrade window
+
+1. Read the PR or release notes to identify which of the three axes changed
+   (proof schema, contract interface, event shape).
+2. If proof schema changed: follow the
+   [Upgrade Procedure](./proof-schema-version-negotiation.md#upgrade-procedure) in
+   the proof schema doc.
+3. If contract interface changed: test the new entry-point signatures against
+   the testnet deployment before the production cutover.
+4. If event shape changed: update indexer consumers to handle both old and new
+   shapes during the transition window; remove old handling after cutover.
+
+### During the upgrade window
+
+- Expect brief unavailability if a `pause` is issued during the upgrade.
+- Subscribe to `PauseManager/paused` and `PauseManager/unpaused` events to track
+  the upgrade window automatically.
+- Do not submit new payroll batches until `PauseManager/unpaused` is received.
+
+### After the upgrade
+
+- Confirm the new contract addresses from the deployment manifest.
+- Run the [Client Integration Checklist](./proof-schema-version-negotiation.md#client-integration-checklist)
+  against the new verifier address.
+- Monitor for 3 consecutive successful payroll runs before reducing alert
+  sensitivity to pre-upgrade levels.
+
+---
+
+## Error Code Reference
+
+Clients should map contract error codes to user-facing messages. Known error
+codes across the payment path:
+
+| Contract | Error code | Enum variant | Recommended client message |
+|----------|-----------|--------------|---------------------------|
+| `payment_executor` | `1` | `ProofAlreadyUsed` | "This payment proof has already been used. Generate a new proof." |
+| `payment_executor` | `2` | `ArrayLengthMismatch` | "Batch input arrays have mismatched lengths. Check serialisation." |
+| `payment_executor` | `3` | `AlreadyPaid` | "This employee has already been paid for this period." |
+| `payment_executor` | `4` | `PeriodNotFound` | "Payroll period does not exist. Create a period before submitting payments." |
+| `payment_executor` | `5` | `PeriodClosed` | "Payroll period is closed. Open a new period." |
+| `payment_executor` | `6` | `PeriodAlreadyExists` | "A period already exists for this company. Close it before creating a new one." |
+| `audit_module` | `1` | `KeyNotFound` | "No view key found for this auditor." |
+| `audit_module` | `2` | `WrongAuditor` | "Caller is not the designated auditor for this key." |
+| `audit_module` | `3` | `KeyExpired` | "Auditor view key has expired. Request a new key." |
+| `audit_module` | `4` | `NotKeyGranter` | "Caller did not grant this key and cannot revoke it." |
+| `audit_module` | `5` | `InsufficientScope` | "View key scope does not permit this operation." |
+| `audit_module` | `6` | `CommitmentMismatch` | "Claimed salary does not match the stored commitment." |
+| `audit_module` | `7` | `InvalidViewKey` | "Supplied view key material is incorrect." |
+
+---
+
+## Related Resources
+
+| Reference | Path |
+|-----------|------|
+| Proof schema version negotiation | [docs/interop/proof-schema-version-negotiation.md](./proof-schema-version-negotiation.md) |
+| Event taxonomy | [docs/monitoring/event-taxonomy.md](../monitoring/event-taxonomy.md) |
+| Event severity mappings | [docs/monitoring/event-severity-mappings.md](../monitoring/event-severity-mappings.md) |
+| Preflight deployment checklist | [docs/ops/preflight-deployment-checklist.md](../ops/preflight-deployment-checklist.md) |
+| Rollback checklist | [docs/ops/rollback-checklist.md](../ops/rollback-checklist.md) |
+| SLA operational targets | [docs/SLA_OPERATIONAL_TARGETS.md](../SLA_OPERATIONAL_TARGETS.md) |
+| Payload examples | [docs/payload-examples.md](../payload-examples.md) |
+
+---
+
+*Closes Issue [#97](https://github.com/zkpayroll/zk-payroll-contracts/issues/97)*

--- a/docs/monitoring/event-taxonomy.md
+++ b/docs/monitoring/event-taxonomy.md
@@ -1,0 +1,299 @@
+# Contract Event Taxonomy — Issue #96
+
+Defines the canonical event taxonomy for all events emitted by ZK Payroll
+contracts. Downstream indexers, dashboards, and SDK consumers should treat
+this document as the authoritative naming and categorisation reference.
+
+Pair with [event-severity-mappings.md](./event-severity-mappings.md) for
+alert routing guidance.
+
+---
+
+## Category Overview
+
+| Category | ID | Contracts | Purpose |
+|----------|----|-----------|---------|
+| Onboarding | `ONB` | `payroll_registry`, `salary_commitment` | Company and employee registration lifecycle |
+| Funding | `FND` | `payroll` | Treasury deposit and balance management |
+| Execution | `EXE` | `payroll`, `payment_executor` | Payroll run and individual payment execution |
+| Audit | `AUD` | `audit_module` | Compliance verification and report generation |
+| Security | `SEC` | `pause_manager`, `payment_executor` | Pause/unpause, replay protection, auth failures |
+
+---
+
+## ONB — Onboarding Events
+
+These events track the lifecycle of companies and employees entering the system.
+They are the expected starting point for any indexer building a roster of active
+participants.
+
+### `CommitmentUpdated`
+
+Emitted by `salary_commitment` when a new commitment is stored or an existing
+one is updated (compensation change).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"CommitmentUpdated"` |
+| topic[1] | `Address` | Employee address |
+| data[0] | `BytesN<32>` | New commitment value (Poseidon hash) |
+
+Notes:
+- Also emitted as part of `rotate_commitment`; distinguish from a rotation by
+  watching for a subsequent `CommitmentRotated` event in the same ledger.
+- The commitment value is a Poseidon hash of `(salary, blinding_factor)` — salary
+  amount is NOT recoverable from this value alone.
+
+### `CommitmentRotated`
+
+Emitted by `salary_commitment` when an existing commitment is explicitly rotated
+(old commitment revoked, new one stored). The old commitment must no longer be
+accepted for future payroll proofs.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"CommitmentRotated"` |
+| topic[1] | `Address` | Employee address |
+| data[0] | `BytesN<32>` | Old (revoked) commitment |
+| data[1] | `BytesN<32>` | New active commitment |
+
+Notes:
+- Indexers that cache commitment values MUST update their local state on this event.
+- A `CommitmentUpdated` event is also emitted in the same call; the rotation event
+  is the authoritative signal that the old value is invalidated.
+
+---
+
+## FND — Funding Events
+
+Funding events track treasury deposits. Indexers monitoring treasury health should
+subscribe to this category.
+
+### `deposit`
+
+Emitted by `payroll` when funds are transferred into the treasury.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"payroll"` |
+| topic[1] | `Symbol` | `"deposit"` |
+| data[0] | `Address` | Source address (depositor) |
+| data[1] | `i128` | Token amount deposited (raw units — divide by token decimals for display) |
+
+Notes:
+- Requires dual authorisation: the `from` address and the `treasury_owner` must both sign.
+- Raw `i128` token units; divide by the token contract's decimal precision before display.
+
+---
+
+## EXE — Execution Events
+
+Execution events represent the core payroll activity. They are the highest-volume
+category under normal operations and the primary input for reconciliation.
+
+### `payment_executed`
+
+Emitted by `payroll` for each individual payment within a `batch_process_payroll` call.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"payroll"` |
+| topic[1] | `Symbol` | `"payment_executed"` |
+| data[0] | `Address` | Employee address |
+| data[1] | `i128` | Amount transferred (raw token units) |
+
+Notes:
+- One event per employee per batch; correlate with `run_executed` using the `run_id`
+  returned by the transaction result.
+- The corresponding nullifier is recorded in `salary_commitment` storage in the same
+  transaction; a `payment_executed` event without a recorded nullifier indicates a bug.
+
+### `run_executed`
+
+Emitted by `payroll` once per `batch_process_payroll` call after all individual
+payments succeed.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"payroll"` |
+| topic[1] | `Symbol` | `"run_executed"` |
+| data[0] | `u64` | Run ID (monotonically increasing, starts at 1) |
+| data[1] | `i128` | Total amount transferred in this run |
+
+Notes:
+- Run IDs are contiguous and monotonically increasing. A gap in run IDs signals a
+  failed or missing batch — investigate immediately.
+- The `PayrollRun` record is queryable on-chain via `get_payroll_run(run_id)`.
+
+### `PayrollProcessed`
+
+Emitted by `payment_executor` for each individual payment executed through the
+period-aware path.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"PayrollProcessed"` |
+| topic[1] | `u64` | Company ID |
+| data[0] | `Address` | Employee address |
+| data[1] | `i128` | Amount transferred (raw token units) |
+| data[2] | `u32` | Period ID |
+
+Notes:
+- Distinguishable from `payment_executed` by the presence of a company ID in the
+  topic and a period ID in the data.
+- Indexers should track per-period totals: sum `data[1]` across all `PayrollProcessed`
+  events sharing the same `topic[1]` (company ID) and `data[2]` (period ID).
+
+### `PeriodCreated`
+
+Emitted by `payment_executor` when a new payroll period is opened for a company.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"PeriodCreated"` |
+| topic[1] | `u64` | Company ID |
+| data[0] | `u32` | Period ID |
+
+### `PeriodClosed`
+
+Emitted by `payment_executor` when a payroll period is closed. No further payments
+can be made in this period after this event.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"PeriodClosed"` |
+| topic[1] | `u64` | Company ID |
+| data[0] | `u32` | Period ID |
+
+Notes:
+- Indexers should mark the period as immutable on receipt of this event.
+- Payment volume for this period can be finalised after `PeriodClosed`.
+
+---
+
+## AUD — Audit Events
+
+Audit events are generated by the `audit_module` when compliance operations are
+performed. They contain only metadata — salary values are never emitted.
+
+### `AuditSuccessful`
+
+Emitted when an auditor's commitment verification passes.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"AuditSuccessful"` |
+| topic[1] | `Address` | Auditor address |
+| data[0] | `AuditScope` | Scope discriminant (see encoding below) |
+| data[1] | `BytesN<32>` | Keyed commitment value (view-key-masked; not the raw salary commitment) |
+
+`AuditScope` encoding (serialised as `u32`):
+
+| Value | Scope |
+|-------|-------|
+| `0` | `FullCompany` |
+| `1` | `TimeRange` |
+| `2` | `EmployeeList` |
+| `3` | `AggregateOnly` |
+
+### `AggregateAuditGenerated`
+
+Emitted when an aggregate compliance report is generated. No individual salary
+data is included.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"AggregateAuditGenerated"` |
+| topic[1] | `Address` | Auditor address |
+| data[0] | `Symbol` | Company ID (string symbol) |
+| data[1] | `u64` | Period start timestamp |
+| data[2] | `u64` | Period end timestamp |
+
+---
+
+## SEC — Security Events
+
+Security events represent operational halts and integrity signals. They should
+be treated with the highest priority by monitoring systems. See
+[event-severity-mappings.md](./event-severity-mappings.md) for alert levels.
+
+### `PauseManager / paused`
+
+Emitted by `pause_manager` when the system is paused.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"PauseManager"` |
+| topic[1] | `Symbol` | `"paused"` |
+| data | `()` | No data payload |
+
+Notes:
+- All payroll execution halts immediately after this event; `batch_process_payroll`
+  and `execute_payment` will panic until unpaused.
+- Treat as `CRITICAL` — page on-call immediately (see severity mappings).
+
+### `PauseManager / unpaused`
+
+Emitted by `pause_manager` when the system resumes.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| topic[0] | `Symbol` | `"PauseManager"` |
+| topic[1] | `Symbol` | `"unpaused"` |
+| data | `()` | No data payload |
+
+Notes:
+- Treat as `HIGH` — verify the root cause of the preceding pause was resolved before
+  accepting this event as routine.
+
+---
+
+## Naming Inconsistencies (Known)
+
+The following inconsistencies exist between the two payment paths and should be
+accounted for in indexer implementations. They will be addressed in a future
+normalisation pass.
+
+| Inconsistency | `payroll` contract | `payment_executor` contract |
+|---------------|--------------------|-----------------------------|
+| Topic format | Two-symbol tuple `("payroll", "payment_executed")` | Single symbol `"PayrollProcessed"` with company ID in topic[1] |
+| Company scoping | No company ID in topic | Company ID in topic[1] |
+| Period tracking | No period concept in `payroll` batch path | Period ID in data[2] |
+| Nullifier recording | Recorded in `salary_commitment` via cross-contract call | Recorded in `payment_executor` own storage (`DataKey::Nullifier`) |
+
+Indexers consuming both paths should normalise to a common schema keyed by
+`(company_id, employee, period, amount, ledger_sequence)`.
+
+---
+
+## Indexer Integration Notes
+
+- All Soroban event topics and data fields are XDR-encoded `ScVal` values. Use
+  the Stellar SDK's `EventFilter` to subscribe by contract address and topic.
+- Subscribe to events by contract address, not just by topic name, to avoid
+  collisions with other contracts using similar symbol names.
+- `i128` amounts are raw token units. Divide by the token contract's decimal
+  precision before storing or displaying.
+- Correlate `payment_executed` events with `run_executed` using the transaction
+  hash (both events appear in the same transaction's event list).
+- For reconciliation, use `get_payroll_run(run_id)` to read the immutable
+  `PayrollRun` record on-chain and compare against indexed payment events.
+
+---
+
+## Related Resources
+
+| Reference | Path |
+|-----------|------|
+| Event severity mappings | [docs/monitoring/event-severity-mappings.md](./event-severity-mappings.md) |
+| Payload examples | [docs/payload-examples.md](../payload-examples.md) |
+| SLA operational targets | [docs/SLA_OPERATIONAL_TARGETS.md](../SLA_OPERATIONAL_TARGETS.md) |
+| `payroll` contract | `contracts/payroll/src/lib.rs` |
+| `payment_executor` contract | `contracts/payment_executor/src/lib.rs` |
+| `salary_commitment` contract | `contracts/salary_commitment/src/lib.rs` |
+| `audit_module` contract | `contracts/audit_module/src/lib.rs` |
+| `pause_manager` contract | `contracts/pause_manager/src/lib.rs` |
+
+---
+
+*Closes Issue [#96](https://github.com/zkpayroll/zk-payroll-contracts/issues/96)*

--- a/docs/ops/rollback-checklist.md
+++ b/docs/ops/rollback-checklist.md
@@ -1,0 +1,185 @@
+# Deployment Rollback Checklist — Issue #98
+
+Use this checklist when a contract deployment or upgrade needs to be reverted.
+It applies to both testnet rehearsals and production incidents. Every item must
+be checked by the operator before marking the rollback complete.
+
+---
+
+## Rollback Triggers
+
+Initiate a rollback when any of the following conditions are confirmed:
+
+| Trigger | Description |
+|---------|-------------|
+| **Smoke test failure** | Any post-deployment smoke test in the preflight checklist fails on a live network |
+| **Proof verification regression** | `verify_payment_proof` returns `false` for proofs that passed on the previous deployment |
+| **Auth bypass detected** | A state-mutating entry-point accepts a call that should have been rejected |
+| **Nullifier storage fault** | Replay protection fails or a nullifier is written to `Temporary` instead of `Persistent` storage |
+| **Pause manager unresponsive** | `is_paused()` returns an unexpected value or the operator key cannot reach the contract |
+| **Treasury misconfiguration** | Post-deployment treasury address or treasury owner does not match the deployment manifest |
+| **Circuit / VK mismatch** | The deployed verification key does not match the checksum recorded during the trusted setup ceremony |
+| **Critical error rate** | Any single operation exceeds a 5% error rate within 30 minutes of deployment |
+
+---
+
+## Prerequisites Before Starting Rollback
+
+- [ ] **Pause payroll immediately** — call `pause` on the `pause_manager` contract before any
+  rollback action to stop new payments while the environment is inconsistent.
+  ```bash
+  stellar contract invoke --id <PAUSE_MGR_ADDR> -- pause
+  stellar contract invoke --id <PAUSE_MGR_ADDR> -- is_paused
+  # Expected: true
+  ```
+
+- [ ] **Previous contract addresses available** — confirm the old contract addresses were
+  recorded in the deployment manifest before the upgrade. If unavailable, check git history
+  and deployment logs before proceeding.
+
+- [ ] **Operator key accessible** — the on-call operator holds the pause manager operator key
+  and the relevant contract admin keys. Verify signing device is responsive.
+
+- [ ] **Incident lead assigned** — at least one person owns the rollback timeline. See the
+  [Incident Response Playbook](../incident-response-playbook.md) for role definitions.
+
+- [ ] **Affected scope documented** — note which contract(s) were upgraded, the block/ledger
+  at which the upgrade was applied, and whether any state was written to the new contract
+  before the rollback was triggered.
+
+---
+
+## Rollback Steps
+
+### Step 1 — Contain
+
+1. Pause the affected contract(s) via `pause_manager`.
+2. Notify the on-call team using the internal alert template in the
+   [Incident Response Playbook](../incident-response-playbook.md#communication-templates).
+3. Capture the failed deployment's contract addresses and ledger range.
+
+### Step 2 — Restore Contract Pointers
+
+Route traffic back to the previous contract version by updating the address
+references in any contracts that depend on the upgraded one.
+
+The dependency chain is (see deployment order in [preflight checklist](./preflight-deployment-checklist.md)):
+
+```
+payroll / payment_executor
+  └── proof_verifier   (ContractAddresses.verifier)
+  └── salary_commitment (ContractAddresses.commitment)
+  └── token            (ContractAddresses.token)
+  └── payroll_registry (ContractAddresses.registry)
+```
+
+For each affected dependency:
+
+- [ ] Confirm the old contract address is live and responding:
+  ```bash
+  stellar contract invoke --id <OLD_CONTRACT_ADDR> -- get_verifier_admin
+  # or equivalent read-only call for that contract
+  ```
+- [ ] If the upgraded contract exposed a setter to update addresses (e.g.,
+  `set_executor_admin`, `set_pause_manager`), call it with the old address.
+  If no setter exists, a new deployment of the *caller* contract pointing to
+  the old dependency address may be required.
+- [ ] Record each restored address in the rollback manifest.
+
+### Step 3 — Verify Rollback State
+
+- [ ] **Verifier admin readable on old contract**:
+  ```bash
+  stellar contract invoke --id <OLD_VERIFIER_ADDR> -- get_verifier_admin
+  ```
+  Expected: returns the intended admin address.
+
+- [ ] **Proof acceptance restored** — submit a known-good test proof against
+  the old verifier on testnet and confirm it returns `true`.
+
+- [ ] **Commitment lookup works** — call `get_commitment` on the old
+  `salary_commitment` address for a known employee and confirm it returns the
+  expected value.
+
+- [ ] **Nullifier set intact** — if the new contract wrote any nullifiers before
+  rollback, verify those nullifiers are also present in the old contract or
+  document them as requiring manual reconciliation.
+
+- [ ] **Pause manager still points to the correct contracts** — re-run the
+  `is_paused()` check and confirm the pause manager operator key can unpause.
+
+### Step 4 — State Validation After Rollback
+
+Salary commitments and nullifiers are stored in `Persistent` storage and are
+not automatically migrated between contract versions. Validate:
+
+| Item | Validation |
+|------|------------|
+| Commitments | All employee commitments from before the failed upgrade are accessible on the old contract address |
+| Nullifiers | Any nullifiers written during the failed deployment window are identified; if written to the new (now-abandoned) contract, they must be recorded off-chain to prevent accidental reuse |
+| Payment records | `PaymentRecord` entries written during the failed window are audited; any duplicate payment risk is flagged to the Incident Lead |
+| Run counter | The payroll run counter (`RunCounter` in `payroll` contract) reflects the expected value; no phantom run IDs were committed |
+
+- [ ] State validation items above confirmed.
+- [ ] Rollback manifest updated with any orphaned state entries.
+
+### Step 5 — Unpause and Monitor
+
+- [ ] Unpause the contract once state validation passes:
+  ```bash
+  stellar contract invoke --id <PAUSE_MGR_ADDR> -- unpause
+  stellar contract invoke --id <PAUSE_MGR_ADDR> -- is_paused
+  # Expected: false
+  ```
+- [ ] Submit one monitored payroll batch (testnet) or a small representative
+  batch (production) and confirm it completes without error.
+- [ ] Monitor for 3 consecutive successful batches before declaring the
+  rollback closed.
+
+---
+
+## Post-Rollback
+
+- [ ] **Root cause documented** — open a follow-up issue describing what went
+  wrong with the failed upgrade and what must change before re-attempting.
+- [ ] **Deployment manifest archived** — save the failed deployment's contract
+  addresses and the rollback manifest in `docs/post-incident/` using the
+  filename format `YYYY-MM-DD-rollback-<short-slug>.md`.
+- [ ] **Preflight checklist updated** — if a gap in the preflight checklist
+  allowed the bad deployment through, update
+  [docs/ops/preflight-deployment-checklist.md](./preflight-deployment-checklist.md).
+- [ ] **Incident report filed** — for any production rollback, a written
+  post-incident review is required within 7 days (see the Incident Response
+  Playbook for the template).
+
+---
+
+## Unsupported Rollback Paths
+
+The following scenarios cannot be handled by this checklist alone and require
+engineering escalation:
+
+| Scenario | Reason |
+|----------|--------|
+| Nullifiers written to new contract only | Persistent storage is not migrated; manual reconciliation is required to avoid replay gaps |
+| Treasury drained before rollback | On-chain transfers are irreversible; requires out-of-band remediation |
+| Verifier VK overwritten | `initialize_verifier` panics on a second call; a fresh contract deploy is required — re-initialization on the same address is not possible |
+| Run counter rolled back | The run counter is monotonic by design; rewinding it would create run ID collisions |
+| Commitment history corrupted | Archived `CommitmentSnapshot` entries are append-only; corrupted history requires off-chain audit support |
+
+---
+
+## Related Resources
+
+| Reference | Path |
+|-----------|------|
+| Preflight deployment checklist | [docs/ops/preflight-deployment-checklist.md](./preflight-deployment-checklist.md) |
+| Incident response playbook | [docs/incident-response-playbook.md](../incident-response-playbook.md) |
+| Proof schema version negotiation | [docs/interop/proof-schema-version-negotiation.md](../interop/proof-schema-version-negotiation.md) |
+| SLA operational targets | [docs/SLA_OPERATIONAL_TARGETS.md](../SLA_OPERATIONAL_TARGETS.md) |
+| Pause manager contract | `contracts/pause_manager/src/lib.rs` |
+| Payment executor security tests | `contracts/payment_executor/tests/security_tests.rs` |
+
+---
+
+*Closes Issue [#98](https://github.com/zkpayroll/zk-payroll-contracts/issues/98)*


### PR DESCRIPTION
Closes #95
Closes #96
Closes #97
Closes #98

## What this adds

Four operational and interop documents that were blocking release readiness and downstream integration work.

`docs/ops/rollback-checklist.md` (#98)
Deployment rollback checklist for failed contract upgrades. Covers rollback triggers, prerequisites (pause first, keys accessible, scope documented), a 5-step operator procedure from containment through state validation to unpausing, unsupported rollback paths specific to this system (VK re-init, monotonic run counter, append-only nullifier stores), and a post-rollback sign-off flow.

`docs/monitoring/event-taxonomy.md` (#96)
Canonical event taxonomy for all contract events grouped into five categories: ONB (onboarding), FND (funding), EXE (execution), AUD (audit), and SEC (security). Each event has full field-level documentation including types, encoding notes, and indexer caveats. Explicitly surfaces the known naming inconsistency between the `payroll` facade and `payment_executor` payment paths so indexers can normalise correctly.

`docs/contributor-module-checklist.md` (#95)
Eight-section checklist for contributors adding or expanding a contract module, covering interface design, authorization, events, storage layout, tests, documentation, security review, and release readiness. Each check links to the concrete file in the repo that demonstrates the expected pattern.

`docs/interop/client-fallback-behavior.md` (#97)
Client fallback guide for older SDK and dashboard clients encountering newer contract interfaces. Defines four supported fallback scenarios with risk levels and handling steps, seven explicitly unsupported downgrade paths with the exact error codes or panic messages clients will see, a full `PaymentError` and `AuditError` reference table, and a migration planning guide tied to the pause event lifecycle.

## Testing
Documentation only — no contract or circuit changes. All existing tests pass unchanged.