### PR TITLE
Fix payment executor test setup for issue 55

### DIFF
--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -502,6 +502,7 @@ mod tests {
         client.initialize(&addresses);
 
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let token_client = TokenClient::new(&env, &addresses.token);
 
         let admin = Address::generate(&env);
@@ -548,6 +549,7 @@ mod tests {
         client.initialize(&addresses);
 
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let token_client = TokenClient::new(&env, &addresses.token);
 
         let admin = Address::generate(&env);
@@ -693,6 +695,7 @@ mod tests {
         client.initialize(&addresses);
 
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let token_client = TokenClient::new(&env, &addresses.token);
 
         let admin = Address::generate(&env);


### PR DESCRIPTION
Closes #55

## Changes
- Fixed the `payment_executor` test module by wiring in the missing `SalaryCommitmentContractClient` setup where commitment storage is required.
- Kept the change limited to the affected test cases so the contract logic itself remains unchanged.

## Why
Several `payment_executor` tests were calling `commitment_client.store_commitment(...)` without creating a commitment client first. That would break compilation and block CI.

## Testing
- Verified the affected test file now defines `commitment_client` before each use.
- I could not run the full Rust test suite in this environment because `cargo` is not available on the current PATH.