### PR TITLE
fix: Add safeguards for duplicate employee registration

### DIFF
--- a/contracts/payroll_registry/src/lib.rs
+++ b/contracts/payroll_registry/src/lib.rs
@@ -92,9 +92,12 @@ impl PayrollRegistryTrait for PayrollRegistry {
 
         info.admin.require_auth();
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Employee(company_id, employee), &commitment);
+        let key = DataKey::Employee(company_id, employee.clone());
+        if env.storage().persistent().has(&key) {
+            panic!("Employee already exists");
+        }
+
+        env.storage().persistent().set(&key, &commitment);
     }
 
     fn remove_employee(env: Env, company_id: u64, employee: Address) {

--- a/contracts/payroll_registry/src/tests.rs
+++ b/contracts/payroll_registry/src/tests.rs
@@ -231,3 +231,41 @@ fn test_get_commitment_returns_employee_commitment() {
     let got = client.get_commitment(&company_id, &employee);
     assert_eq!(got, commitment);
 }
+
+#[test]
+#[should_panic(expected = "Employee already exists")]
+fn test_add_employee_rejects_duplicate() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let commitment = BytesN::from_array(&env, &[1u8; 32]);
+
+    let company_id = client.register_company(&admin, &treasury);
+    client.add_employee(&company_id, &employee, &commitment);
+    // Should panic
+    client.add_employee(&company_id, &employee, &commitment);
+}
+
+#[test]
+fn test_add_employee_allows_re_onboarding_after_removal() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let commitment1 = BytesN::from_array(&env, &[1u8; 32]);
+    let commitment2 = BytesN::from_array(&env, &[2u8; 32]);
+
+    let company_id = client.register_company(&admin, &treasury);
+    
+    client.add_employee(&company_id, &employee, &commitment1);
+    client.remove_employee(&company_id, &employee);
+    
+    // Should succeed because employee was removed
+    client.add_employee(&company_id, &employee, &commitment2);
+
+    let got = client.get_commitment(&company_id, &employee);
+    assert_eq!(got, commitment2);
+}


### PR DESCRIPTION
## Overview
This PR implements checks to prevent the same employee from being registered multiple times within a single company in the payroll registry.

## Changes Included
- **Duplicate Checks (#92):** Updated `add_employee` in `payroll_registry` to check if the employee's `DataKey` already exists. If it does, the contract panics with "Employee already exists".
- **Re-onboarding:** Validated that legitimate lifecycle updates (re-onboarding after offboarding via `remove_employee`) remain functional, as `remove_employee` completely removes the registry entry.
- **Tests:** Added `test_add_employee_rejects_duplicate` and `test_add_employee_allows_re_onboarding_after_removal` to cover the new constraints.

Fixes #92
Fixes #78
Fixes #76
Fixes #107