### PR TITLE
feat(payroll): Add payroll run reconciliation status for downstream settlement tracking 

### DIFF
--- a/PR_DESCRIPTION_134.md
+++ b/PR_DESCRIPTION_134.md
@@ -1,0 +1,27 @@
+# PR Description
+
+## Title
+`feat(payroll): Add payroll run reconciliation status for downstream settlement tracking (#134)`
+
+## Description
+This PR introduces reconciliation status tracking for completed payroll runs to support downstream settlement integrations.
+
+### Key Changes
+- **Reconciliation States**: Added the `ReconciliationStatus` enum representing the three phases: `Unreconciled` (initial state), `Reconciled` (settlement success), and `Failed` (settlement exception).
+- **Payroll Run Linking**: Added the `reconciliation_status` field to the `PayrollRun` struct and initialized new runs as `Unreconciled` at execution time inside `batch_process_payroll`.
+- **Admin Reconciliation Updates**: Implemented the `update_reconciliation_status` entry-point, allowing contract administrators to update run status and publishing a `reconciliation_updated` event on success.
+- **Client Guidelines Documentation**: Added `docs/interop/reconciliation-status.md` which documents reconciliation states, transitions, event structures, and recommendations for downstream integration.
+
+## How Was This Tested?
+- Added unit tests covering the entire reconciliation lifecycle:
+  - `test_new_run_is_unreconciled`
+  - `test_admin_can_update_reconciliation_status`
+  - `test_non_admin_cannot_update_reconciliation_status` (asserts panic on unauthorized updates)
+  - `test_update_status_for_invalid_run_panics` (asserts panic when targeting non-existent run IDs)
+- Verified all contract tests pass successfully in the local workspace using:
+  ```bash
+  cargo test -p payroll --release
+  ```
+
+## Closes
+Closes #134

--- a/contracts/integration_tests/src/lib.rs
+++ b/contracts/integration_tests/src/lib.rs
@@ -75,6 +75,13 @@ mod e2e {
         commitment_client.compute_commitment(&5000u64, &blinding_factor)
     }
 
+    /// Generates a unique 32-byte nonce from a counter seed for tests.
+    fn test_nonce(env: &Env, seed: u8) -> BytesN<32> {
+        let mut arr = [0u8; 32];
+        arr[0] = seed;
+        BytesN::from_array(env, &arr)
+    }
+
     // ── Helper: register & initialise all five contracts ─────────────────────
 
     struct TestContext<'a> {
@@ -96,6 +103,7 @@ mod e2e {
         // ── Register contracts ───────────────────────────────────────────────
         let admin = Address::generate(&env);
         let treasury = Address::generate(&env);
+        let treasury_owner = Address::generate(&env);
         let alice = Address::generate(&env);
 
         let verifier_id = env.register_contract(None, ProofVerifier);
@@ -115,7 +123,14 @@ mod e2e {
 
         // ── Initialise payroll executor ───────────────────────────────────────
         let payroll_client = PayrollClient::new(&env, &payroll_id);
-        payroll_client.initialize(&admin, &token_id, &verifier_id, &commitment_id, &treasury);
+        payroll_client.initialize(
+            &admin,
+            &token_id,
+            &verifier_id,
+            &commitment_id,
+            &treasury,
+            &treasury_owner,
+        );
 
         let commitment_client_init = SalaryCommitmentContractClient::new(&env, &commitment_id);
         commitment_client_init.set_payroll_operator(&payroll_id);
@@ -183,8 +198,14 @@ mod e2e {
 
         // Execute batch payroll: verifier checks proof, commitment is retrieved,
         // nullifier is recorded, and the token transfer is executed.
-        ctx.payroll_client
-            .batch_process_payroll(&proofs, &amounts, &employees, &payment_amount);
+        ctx.payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &payment_amount,
+            &test_nonce(env, 1),
+            &None,
+        );
 
         // ── ASSERTIONS ────────────────────────────────────────────────────────
 
@@ -240,8 +261,14 @@ mod e2e {
         let mut employees = Vec::new(env);
         employees.push_back(ctx.alice.clone());
 
-        ctx.payroll_client
-            .batch_process_payroll(&proofs, &amounts, &employees, &5_000i128);
+        ctx.payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &5_000i128,
+            &test_nonce(env, 2),
+            &None,
+        );
     }
 
     /// Running payroll twice for the same employee reuses the nullifier and must panic.
@@ -272,13 +299,25 @@ mod e2e {
 
         // First payroll run succeeds.
         let (proofs, amounts, employees) = make_batch(env, &ctx.alice);
-        ctx.payroll_client
-            .batch_process_payroll(&proofs, &amounts, &employees, &5_000i128);
+        ctx.payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &5_000i128,
+            &test_nonce(env, 3),
+            &None,
+        );
 
         // Second payroll run with the same nullifier (batch index 0) must panic.
         let (proofs2, amounts2, employees2) = make_batch(env, &ctx.alice);
-        ctx.payroll_client
-            .batch_process_payroll(&proofs2, &amounts2, &employees2, &5_000i128);
+        ctx.payroll_client.batch_process_payroll(
+            &proofs2,
+            &amounts2,
+            &employees2,
+            &5_000i128,
+            &test_nonce(env, 4),
+            &None,
+        );
     }
 
     /// Array length mismatches must be rejected immediately.
@@ -300,8 +339,14 @@ mod e2e {
         employees.push_back(ctx.alice.clone());
         employees.push_back(ctx.alice.clone());
 
-        ctx.payroll_client
-            .batch_process_payroll(&proofs, &amounts, &employees, &5_000i128);
+        ctx.payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &5_000i128,
+            &test_nonce(env, 5),
+            &None,
+        );
     }
 
     // ── Dynamic proof generation test ─────────────────────────────────────────
@@ -365,8 +410,14 @@ mod e2e {
         amounts.push_back(payment_amount);
         employees.push_back(ctx.alice.clone());
 
-        ctx.payroll_client
-            .batch_process_payroll(&proofs, &amounts, &employees, &payment_amount);
+        ctx.payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &payment_amount,
+            &test_nonce(env, 6),
+            &None,
+        );
 
         assert_eq!(
             ctx.token_client.balance(&ctx.treasury),

--- a/contracts/integration_tests/src/lib.rs
+++ b/contracts/integration_tests/src/lib.rs
@@ -230,14 +230,15 @@ mod e2e {
             "Payment nullifier must be recorded after execution"
         );
 
-        // 4. Exactly two events must have been emitted across the full flow:
+        // 4. Exactly three events must have been emitted across the full flow:
         //      - `CommitmentUpdated` from salary_commitment.store_commitment (onboarding)
         //      - `payment_executed`  from payroll.batch_process_payroll    (execution)
+        //      - `run_executed`      from payroll.batch_process_payroll    (execution)
         let events = env.events().all();
         assert_eq!(
             events.len(),
-            2,
-            "Expected 2 events: CommitmentUpdated (onboarding) + payment_executed (execution)"
+            3,
+            "Expected 3 events: CommitmentUpdated (onboarding) + payment_executed (execution) + run_executed (execution)"
         );
     }
 

--- a/contracts/integration_tests/src/upgrade_simulation.rs
+++ b/contracts/integration_tests/src/upgrade_simulation.rs
@@ -25,6 +25,7 @@
 //! network or Node.js installation required.
 
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod upgrade_simulation {
     use payroll_registry::{PayrollRegistry, PayrollRegistryClient};
     use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -858,6 +858,7 @@ mod tests {
         client.initialize(&addresses);
 
         let registry_client = PayrollRegistryClient::new(env, &addresses.registry);
+        let commitment_client = SalaryCommitmentContractClient::new(env, &addresses.commitment);
         let token_client = TokenClient::new(env, &addresses.token);
 
         let admin = Address::generate(env);
@@ -866,6 +867,7 @@ mod tests {
         let commitment = BytesN::from_array(env, &[9u8; 32]);
 
         let company_id = registry_client.register_company(&admin, &treasury);
+        commitment_client.store_commitment(&employee, &commitment);
         registry_client.add_employee(&company_id, &employee, &commitment);
         token_client.mint(&treasury, &10_000);
 
@@ -966,6 +968,7 @@ mod tests {
         client.initialize(&addresses);
 
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let token_client = TokenClient::new(&env, &addresses.token);
 
         let admin = Address::generate(&env);
@@ -974,6 +977,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[9u8; 32]);
 
         let company_id = registry_client.register_company(&admin, &treasury);
+        commitment_client.store_commitment(&employee, &commitment);
         registry_client.add_employee(&company_id, &employee, &commitment);
         client.create_period(&company_id);
         token_client.mint(&treasury, &10_000);

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -695,7 +695,6 @@ mod tests {
         client.initialize(&addresses);
 
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
-        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let token_client = TokenClient::new(&env, &addresses.token);
 
         let admin = Address::generate(&env);
@@ -781,6 +780,7 @@ mod tests {
         client.initialize(&addresses);
 
         let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
         let token_client = TokenClient::new(&env, &addresses.token);
 
         let admin = Address::generate(&env);

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -441,6 +441,10 @@ mod tests {
         verifier_client.init_verifier_admin(&verifier_admin);
         verifier_client.initialize_verifier(&mock_vk(env));
 
+        let commitment_client = SalaryCommitmentContractClient::new(env, &commitment_id);
+        let commitment_admin = Address::generate(env);
+        commitment_client.init_commitment_admin(&commitment_admin);
+
         ContractAddresses {
             registry: registry_id,
             commitment: commitment_id,

--- a/contracts/payment_executor/tests/security_tests.rs
+++ b/contracts/payment_executor/tests/security_tests.rs
@@ -60,6 +60,9 @@ fn setup_system<'a>(
     verifier.init_verifier_admin(&Address::generate(env));
     verifier.initialize_verifier(&mock_vk(env));
 
+    let commitment_admin = Address::generate(env);
+    commitment_client.init_commitment_admin(&commitment_admin);
+
     let admin = Address::generate(env);
     let treasury = Address::generate(env);
 

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -24,6 +24,15 @@ pub struct ContractAddresses {
     pub treasury_owner: Address,
 }
 
+/// Reconciliation status for completed payroll runs.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReconciliationStatus {
+    Unreconciled,
+    Reconciled,
+    Failed,
+}
+
 /// A completed payroll run record.
 ///
 /// `draft_hash` is the SHA-256 / Poseidon hash of the off-chain payroll
@@ -45,6 +54,7 @@ pub struct PayrollRun {
     pub draft_hash: BytesN<32>,
     /// Caller-supplied run nonce (issue #103). Unique per contract lifetime.
     pub nonce: BytesN<32>,
+    pub reconciliation_status: ReconciliationStatus,
 }
 
 /// Pending emergency withdrawal request (issue #104).
@@ -441,6 +451,7 @@ impl Payroll {
             employee_count: count,
             draft_hash: resolved_draft_hash,
             nonce: nonce.clone(),
+            reconciliation_status: ReconciliationStatus::Unreconciled,
         };
         e.storage()
             .persistent()
@@ -452,6 +463,42 @@ impl Payroll {
         );
 
         run_id
+    }
+
+    /// Update the reconciliation status of a completed payroll run.
+    ///
+    /// Only the `admin` may update the reconciliation status.
+    /// Emits a `reconciliation_updated` event.
+    pub fn update_reconciliation_status(
+        e: Env,
+        admin: Address,
+        run_id: u64,
+        status: ReconciliationStatus,
+    ) {
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+
+        let run_key = DataKey::PayrollRun(run_id);
+        let mut run: PayrollRun = e
+            .storage()
+            .persistent()
+            .get(&run_key)
+            .expect("Run not found");
+
+        run.reconciliation_status = status;
+        e.storage().persistent().set(&run_key, &run);
+
+        e.events().publish(
+            (symbol_short!("payroll"), Symbol::new(&e, "reconciliation_updated")),
+            (run_id, status),
+        );
     }
 }
 
@@ -1085,5 +1132,85 @@ mod tests {
         let recipient = Address::generate(&env);
         payroll_client.request_emergency_withdrawal(&treasury_owner, &100i128, &recipient);
         payroll_client.request_emergency_withdrawal(&treasury_owner, &200i128, &recipient);
+    }
+
+    // ── Issue #134: reconciliation status tracking ─────────────────────────────
+
+    #[test]
+    fn test_new_run_is_unreconciled() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&env, 30),
+            &None,
+        );
+
+        let run = payroll_client.get_payroll_run(&run_id);
+        assert_eq!(run.reconciliation_status, ReconciliationStatus::Unreconciled);
+    }
+
+    #[test]
+    fn test_admin_can_update_reconciliation_status() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&env, 31),
+            &None,
+        );
+
+        // Update to Reconciled
+        payroll_client.update_reconciliation_status(&admin, &run_id, &ReconciliationStatus::Reconciled);
+        let run = payroll_client.get_payroll_run(&run_id);
+        assert_eq!(run.reconciliation_status, ReconciliationStatus::Reconciled);
+
+        // Update to Failed
+        payroll_client.update_reconciliation_status(&admin, &run_id, &ReconciliationStatus::Failed);
+        let run = payroll_client.get_payroll_run(&run_id);
+        assert_eq!(run.reconciliation_status, ReconciliationStatus::Failed);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized")]
+    fn test_non_admin_cannot_update_reconciliation_status() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&env, 32),
+            &None,
+        );
+
+        let non_admin = Address::generate(&env);
+        payroll_client.update_reconciliation_status(&non_admin, &run_id, &ReconciliationStatus::Reconciled);
+    }
+
+    #[test]
+    #[should_panic(expected = "Run not found")]
+    fn test_update_status_for_invalid_run_panics() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        payroll_client.update_reconciliation_status(&admin, &999u64, &ReconciliationStatus::Reconciled);
     }
 }

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -496,7 +496,10 @@ impl Payroll {
         e.storage().persistent().set(&run_key, &run);
 
         e.events().publish(
-            (symbol_short!("payroll"), Symbol::new(&e, "reconciliation_updated")),
+            (
+                symbol_short!("payroll"),
+                Symbol::new(&e, "reconciliation_updated"),
+            ),
             (run_id, status),
         );
     }
@@ -1153,7 +1156,10 @@ mod tests {
         );
 
         let run = payroll_client.get_payroll_run(&run_id);
-        assert_eq!(run.reconciliation_status, ReconciliationStatus::Unreconciled);
+        assert_eq!(
+            run.reconciliation_status,
+            ReconciliationStatus::Unreconciled
+        );
     }
 
     #[test]
@@ -1173,7 +1179,11 @@ mod tests {
         );
 
         // Update to Reconciled
-        payroll_client.update_reconciliation_status(&admin, &run_id, &ReconciliationStatus::Reconciled);
+        payroll_client.update_reconciliation_status(
+            &admin,
+            &run_id,
+            &ReconciliationStatus::Reconciled,
+        );
         let run = payroll_client.get_payroll_run(&run_id);
         assert_eq!(run.reconciliation_status, ReconciliationStatus::Reconciled);
 
@@ -1201,7 +1211,11 @@ mod tests {
         );
 
         let non_admin = Address::generate(&env);
-        payroll_client.update_reconciliation_status(&non_admin, &run_id, &ReconciliationStatus::Reconciled);
+        payroll_client.update_reconciliation_status(
+            &non_admin,
+            &run_id,
+            &ReconciliationStatus::Reconciled,
+        );
     }
 
     #[test]
@@ -1211,6 +1225,10 @@ mod tests {
         let (payroll_client, admin, _treasury, _treasury_owner, _employee) =
             setup_simple_payroll(&env);
 
-        payroll_client.update_reconciliation_status(&admin, &999u64, &ReconciliationStatus::Reconciled);
+        payroll_client.update_reconciliation_status(
+            &admin,
+            &999u64,
+            &ReconciliationStatus::Reconciled,
+        );
     }
 }

--- a/docs/interop/reconciliation-status.md
+++ b/docs/interop/reconciliation-status.md
@@ -1,0 +1,103 @@
+# Payroll Run Reconciliation Status — Issue #134
+
+This document defines the reconciliation states, state transitions, and integration guidelines for downstream systems tracking completed payroll runs.
+
+---
+
+## Background
+
+On-chain payroll execution is the first phase of the payment lifecycle: funds are transferred to employee addresses. However, downstream business systems (ERPs, general ledgers, sub-ledgers, and off-chain bank gateways) require a way to verify and log whether the executed payroll run has been fully settled and reconciled.
+
+The payroll contract exposes a `reconciliation_status` field on `PayrollRun` records and provides an admin entry-point to update this status.
+
+---
+
+## Reconciliation States
+
+| State | Description | Client Action / Interpretation |
+|---|---|---|
+| `Unreconciled` | The default initial state of any payroll run upon execution. Payments have been sent on-chain, but the run has not yet been matched against downstream bank statements or ledger records. | **Pending**: Await automated reconciliation processing or manual verification. Do not mark as final in accounting logs. |
+| `Reconciled` | The payroll run has been successfully matched and verified against downstream banking gateways and general ledgers. | **Complete**: Safe to close out this payroll run in downstream accounting databases and generate final reports. |
+| `Failed` | An anomaly, payment rejection, or reconciliation discrepancy was detected during the settlement process (e.g. a treasury withdrawal failed off-chain, or an employee address was blacklisted). | **Exception**: Raise a high-priority alert. Freeze dependent workflows. Flag this run for manual audit and correction. |
+
+---
+
+## State Transitions
+
+### Lifecycle Flow
+
+```mermaid
+graph TD
+    Start([batch_process_payroll]) --> Unreconciled[Unreconciled]
+    Unreconciled -->|update_reconciliation_status| Reconciled[Reconciled]
+    Unreconciled -->|update_reconciliation_status| Failed[Failed]
+    Failed -->|Manual correction & update| Reconciled
+    Reconciled -->|Post-settlement audit adjustment| Failed
+```
+
+1. **Initialization**: Every payroll run created via `batch_process_payroll` starts in the `Unreconciled` state.
+2. **Standard Path**: The reconciliation engine verifies the payments off-chain and updates the run to `Reconciled`.
+3. **Exception Path**: If a discrepancy is found, the engine or admin marks the run as `Failed`.
+4. **Correction Path**: Once a failed run is manually adjusted or corrected in the downstream system, the admin may transition the run from `Failed` to `Reconciled`.
+
+---
+
+## Technical Specifications
+
+### Event Taxonomy
+
+Whenever the reconciliation status is updated, the contract publishes a `reconciliation_updated` event under the `payroll` topic namespace:
+
+- **Topic**: `(symbol_short!("payroll"), Symbol::new(&e, "reconciliation_updated"))`
+- **Data Payload**: `(run_id: u64, status: ReconciliationStatus)`
+
+### API Integration
+
+#### Querying Status
+
+Clients can retrieve a payroll run's current status on-chain by calling:
+
+```rust
+pub fn get_payroll_run(e: Env, run_id: u64) -> PayrollRun
+```
+
+The returned `PayrollRun` struct includes the `reconciliation_status` field:
+
+```rust
+pub struct PayrollRun {
+    pub run_id: u64,
+    pub executed_at: u64,
+    pub admin: Address,
+    pub total_amount: i128,
+    pub employee_count: u32,
+    pub draft_hash: BytesN<32>,
+    pub nonce: BytesN<32>,
+    pub reconciliation_status: ReconciliationStatus,
+}
+```
+
+#### Modifying Status
+
+Only the contract `admin` can update the status by calling:
+
+```rust
+pub fn update_reconciliation_status(
+    e: Env,
+    admin: Address,
+    run_id: u64,
+    status: ReconciliationStatus,
+)
+```
+
+---
+
+## Client Integration Guidelines
+
+1. **Subscribing to Updates**:
+   Downstream systems SHOULD subscribe to the Soroban event stream for `reconciliation_updated` events. On receiving an update, downstream databases should sync the corresponding `run_id` status.
+
+2. **Error Handling**:
+   When a run status changes to `Failed`, clients MUST trigger alerts in operational dashboards. Any downstream processing depending on the settlement (e.g. tax filings, payroll audits) should be suspended for that specific run until it transitions to `Reconciled`.
+
+3. **Graceful Degrade**:
+   If an older client does not support the `reconciliation_status` field on older contract instances, the SDK ignores the trailing field when reading `PayrollRun` records (refer to [Client Fallback Behavior](./client-fallback-behavior.md)).


### PR DESCRIPTION
Closes #134 

## Description
This PR introduces reconciliation status tracking for completed payroll runs to support downstream settlement integrations.

### Key Changes
- **Reconciliation States**: Added the `ReconciliationStatus` enum representing the three phases: `Unreconciled` (initial state), `Reconciled` (settlement success), and `Failed` (settlement exception).
- **Payroll Run Linking**: Added the `reconciliation_status` field to the `PayrollRun` struct and initialized new runs as `Unreconciled` at execution time inside `batch_process_payroll`.
- **Admin Reconciliation Updates**: Implemented the `update_reconciliation_status` entry-point, allowing contract administrators to update run status and publishing a `reconciliation_updated` event on success.
- **Client Guidelines Documentation**: Added `docs/interop/reconciliation-status.md` which documents reconciliation states, transitions, event structures, and recommendations for downstream integration.
- **Test Suite Alignment**: Fixed pre-existing compiler, clippy, and runtime errors in `payment_executor` and `integration_tests` packages to ensure that the entire workspace compiles and tests pass cleanly.

## How Was This Tested?
- Added unit tests covering the entire reconciliation lifecycle:
  - `test_new_run_is_unreconciled`
  - `test_admin_can_update_reconciliation_status`
  - `test_non_admin_cannot_update_reconciliation_status` (asserts panic on unauthorized updates)
  - `test_update_status_for_invalid_run_panics` (asserts panic when targeting non-existent run IDs)
- Verified all contract tests pass successfully in the local workspace using:
  ```bash
  cargo test --workspace --release