### PR TITLE
test(payroll_registry): add duplicate company registration rejection …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,9 +814,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fallible-iterator"

--- a/contracts/audit_module/src/lib.rs
+++ b/contracts/audit_module/src/lib.rs
@@ -196,7 +196,11 @@ impl AuditModule {
 
         // Emit revocation event for audit trail
         env.events().publish(
-            (Symbol::new(&env, "AuditAccessRevoked"), admin, auditor.clone()),
+            (
+                Symbol::new(&env, "AuditAccessRevoked"),
+                admin,
+                auditor.clone(),
+            ),
             (env.ledger().timestamp(),),
         );
         // topics : ("AuditAccessRevoked", admin, auditor)
@@ -492,10 +496,7 @@ impl AuditModule {
         };
 
         env.events().publish(
-            (
-                Symbol::new(&env, "AuditSummaryExported"),
-                auditor,
-            ),
+            (Symbol::new(&env, "AuditSummaryExported"), auditor),
             (company_id, period_start, period_end, total),
         );
 

--- a/contracts/audit_module/src/tests.rs
+++ b/contracts/audit_module/src/tests.rs
@@ -526,8 +526,7 @@ fn test_export_audit_summary_returns_correct_counts() {
 
     let company_id = Symbol::new(&env, "default");
     let ts = env.ledger().timestamp();
-    let summary =
-        client.export_audit_summary(&auditor, &company_id, &0u64, &(ts + 1_000_000u64));
+    let summary = client.export_audit_summary(&auditor, &company_id, &0u64, &(ts + 1_000_000u64));
 
     assert_eq!(summary.company_id, company_id);
     assert_eq!(summary.exported_by, auditor);
@@ -564,12 +563,8 @@ fn test_export_audit_summary_excludes_out_of_period_entries() {
     let company_id = Symbol::new(&env, "default");
     // Request a period that is far in the future — no entries should match.
     let far_future: u64 = 999_999_999_999;
-    let summary = client.export_audit_summary(
-        &auditor,
-        &company_id,
-        &far_future,
-        &(far_future + 1_000),
-    );
+    let summary =
+        client.export_audit_summary(&auditor, &company_id, &far_future, &(far_future + 1_000));
 
     assert_eq!(summary.total_audit_entries, 0);
     assert_eq!(summary.verification_pass_count, 0);

--- a/contracts/integration_tests/src/lib.rs
+++ b/contracts/integration_tests/src/lib.rs
@@ -30,15 +30,15 @@ mod proof_helper;
 ///      unregistered employees cannot be paid.
 #[cfg(test)]
 mod e2e {
-    use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
     use payroll::{Payroll, PayrollClient};
     use payroll_registry::{PayrollRegistry, PayrollRegistryClient};
+    use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
     use salary_commitment::{SalaryCommitmentContract, SalaryCommitmentContractClient};
-    use token::{Token, TokenClient};
     use soroban_sdk::{
         testutils::{Address as _, Events},
         Address, BytesN, Env, Symbol, TryIntoVal, Vec,
     };
+    use token::{Token, TokenClient};
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/contracts/module_template/src/lib.rs
+++ b/contracts/module_template/src/lib.rs
@@ -100,29 +100,27 @@ impl ModuleTemplate {
     }
 }
 
-
-    // TODO: implement module-specific entry-points below.
-    //
-    // Pattern for admin-gated mutation:
-    //
-    //   pub fn some_action(e: Env, admin: Address, ...) -> Result<(), ModuleError> {
-    //       let stored: Address = e
-    //           .storage()
-    //           .persistent()
-    //           .get(&DataKey::Admin)
-    //           .ok_or(ModuleError::NotInitialized)?;
-    //       if admin != stored { return Err(ModuleError::Unauthorized); }
-    //       admin.require_auth();
-    //
-    //       // ... mutate state ...
-    //
-    //       e.events().publish(
-    //           (symbol_short!("module"), Symbol::new(&e, "some_action")),
-    //           /* event data */,
-    //       );
-    //       Ok(())
-    //   }
-}
+// TODO: implement module-specific entry-points below.
+//
+// Pattern for admin-gated mutation:
+//
+//   pub fn some_action(e: Env, admin: Address, ...) -> Result<(), ModuleError> {
+//       let stored: Address = e
+//           .storage()
+//           .persistent()
+//           .get(&DataKey::Admin)
+//           .ok_or(ModuleError::NotInitialized)?;
+//       if admin != stored { return Err(ModuleError::Unauthorized); }
+//       admin.require_auth();
+//
+//       // ... mutate state ...
+//
+//       e.events().publish(
+//           (symbol_short!("module"), Symbol::new(&e, "some_action")),
+//           /* event data */,
+//       );
+//       Ok(())
+//   }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -135,9 +133,6 @@ mod tests {
     fn test_initialize_sets_admin() {
         let env = Env::default();
         env.mock_all_auths();
-        let contract_id = env.register_contract(None, ModuleTemplate);
-        let client = ModuleTemplateClient::new(&env, &contract_id);
-
         let contract_id = env.register_contract(None, ModuleTemplate);
         let client = ModuleTemplateClient::new(&env, &contract_id);
 
@@ -154,16 +149,6 @@ mod tests {
         let client = ModuleTemplateClient::new(&env, &contract_id);
         let admin = Address::generate(&env);
         client.initialize(&admin);
-        let result = client.try_initialize(&admin);
-        assert_eq!(result, Err(Ok(ModuleError::AlreadyInitialized)));
-    }
-
-        let contract_id = env.register_contract(None, ModuleTemplate);
-        let client = ModuleTemplateClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        client.initialize(&admin);
-
         let result = client.try_initialize(&admin);
         assert_eq!(result, Err(Ok(ModuleError::AlreadyInitialized)));
     }

--- a/contracts/payment_executor/tests/security_tests.rs
+++ b/contracts/payment_executor/tests/security_tests.rs
@@ -303,7 +303,10 @@ fn test_retry_across_periods_succeeds_with_new_period() {
         &nullifier_1,
         &1,
     );
-    assert_eq!(replay_1.unwrap_err().unwrap(), PaymentError::ProofAlreadyUsed);
+    assert_eq!(
+        replay_1.unwrap_err().unwrap(),
+        PaymentError::ProofAlreadyUsed
+    );
 
     let replay_2 = executor.try_execute_payment(
         &company_id,
@@ -315,7 +318,10 @@ fn test_retry_across_periods_succeeds_with_new_period() {
         &nullifier_2,
         &2,
     );
-    assert_eq!(replay_2.unwrap_err().unwrap(), PaymentError::ProofAlreadyUsed);
+    assert_eq!(
+        replay_2.unwrap_err().unwrap(),
+        PaymentError::ProofAlreadyUsed
+    );
 }
 
 /// Acceptance Criteria: Idempotent Retry Within Same Period
@@ -341,7 +347,16 @@ fn test_retry_same_period_detects_already_paid() {
     let nullifier = BytesN::from_array(&env, &[63u8; 32]);
 
     // First payment in period 1
-    executor.execute_payment(&company_id, &employee, &1000, &proof_a, &proof_b, &proof_c, &nullifier, &1);
+    executor.execute_payment(
+        &company_id,
+        &employee,
+        &1000,
+        &proof_a,
+        &proof_b,
+        &proof_c,
+        &nullifier,
+        &1,
+    );
 
     assert!(executor.is_paid(&employee, &1));
     assert_eq!(executor.get_total_paid(&company_id), 1000);
@@ -359,7 +374,10 @@ fn test_retry_same_period_detects_already_paid() {
     );
 
     // Should fail due to ProofAlreadyUsed (nullifier already consumed)
-    assert_eq!(retry_result.unwrap_err().unwrap(), PaymentError::ProofAlreadyUsed);
+    assert_eq!(
+        retry_result.unwrap_err().unwrap(),
+        PaymentError::ProofAlreadyUsed
+    );
 
     // Verify no duplicate payment was recorded
     assert_eq!(executor.get_total_paid(&company_id), 1000);
@@ -388,7 +406,16 @@ fn test_period_isolation_prevents_cross_period_replay() {
     let nullifier = BytesN::from_array(&env, &[83u8; 32]);
 
     // Execute payment in period 1
-    executor.execute_payment(&company_id, &employee, &2000, &proof_a, &proof_b, &proof_c, &nullifier, &1);
+    executor.execute_payment(
+        &company_id,
+        &employee,
+        &2000,
+        &proof_a,
+        &proof_b,
+        &proof_c,
+        &nullifier,
+        &1,
+    );
     assert!(executor.is_paid(&employee, &1));
 
     // Create a new period (period 2)
@@ -407,7 +434,10 @@ fn test_period_isolation_prevents_cross_period_replay() {
     );
 
     // Should fail because nullifier was already consumed in period 1
-    assert_eq!(cross_period_result.unwrap_err().unwrap(), PaymentError::ProofAlreadyUsed);
+    assert_eq!(
+        cross_period_result.unwrap_err().unwrap(),
+        PaymentError::ProofAlreadyUsed
+    );
 
     // Verify employee is not marked as paid in period 2
     assert!(!executor.is_paid(&employee, &2));
@@ -491,7 +521,10 @@ fn test_retry_multiple_employees_detects_duplicates() {
         &nullifier_1,
         &1,
     );
-    assert_eq!(replay_1.unwrap_err().unwrap(), PaymentError::ProofAlreadyUsed);
+    assert_eq!(
+        replay_1.unwrap_err().unwrap(),
+        PaymentError::ProofAlreadyUsed
+    );
 
     let replay_2 = executor.try_execute_payment(
         &company_id,
@@ -503,7 +536,10 @@ fn test_retry_multiple_employees_detects_duplicates() {
         &nullifier_2,
         &1,
     );
-    assert_eq!(replay_2.unwrap_err().unwrap(), PaymentError::ProofAlreadyUsed);
+    assert_eq!(
+        replay_2.unwrap_err().unwrap(),
+        PaymentError::ProofAlreadyUsed
+    );
 
     // Attempt to pay employee A again with different proof (should fail with AlreadyPaid)
     let proof_a_3 = BytesN::from_array(&env, &[120u8; 64]);
@@ -521,7 +557,10 @@ fn test_retry_multiple_employees_detects_duplicates() {
         &nullifier_3,
         &1,
     );
-    assert_eq!(double_pay_result.unwrap_err().unwrap(), PaymentError::AlreadyPaid);
+    assert_eq!(
+        double_pay_result.unwrap_err().unwrap(),
+        PaymentError::AlreadyPaid
+    );
 
     // Final verification: total paid unchanged
     assert_eq!(executor.get_total_paid(&company_id), 800);

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -502,9 +502,7 @@ impl Payroll {
 
     /// Get a pending payroll run, if it exists.
     pub fn get_pending_run(e: Env, run_id: u64) -> Option<PendingPayrollRun> {
-        e.storage()
-            .persistent()
-            .get(&DataKey::PendingRun(run_id))
+        e.storage().persistent().get(&DataKey::PendingRun(run_id))
     }
 
     /// Cancel a pending payroll run without executing any payments.
@@ -750,15 +748,6 @@ impl Payroll {
         draft_id: u64,
         new_total_amount: i128,
         new_employee_count: u32,
-    /// Update the reconciliation status of a completed payroll run.
-    ///
-    /// Only the `admin` may update the reconciliation status.
-    /// Emits a `reconciliation_updated` event.
-    pub fn update_reconciliation_status(
-        e: Env,
-        admin: Address,
-        run_id: u64,
-        status: ReconciliationStatus,
     ) {
         let addrs: ContractAddresses = e
             .storage()
@@ -794,6 +783,45 @@ impl Payroll {
         e.events().publish(
             (symbol_short!("payroll"), Symbol::new(&e, "draft_amended")),
             (draft_id, new_total_amount, draft.amendment_count),
+        );
+    }
+
+    /// Update the reconciliation status of a completed payroll run.
+    ///
+    /// Only the `admin` may update the reconciliation status.
+    /// Emits a `reconciliation_updated` event.
+    pub fn update_reconciliation_status(
+        e: Env,
+        admin: Address,
+        run_id: u64,
+        status: ReconciliationStatus,
+    ) {
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+
+        let run_key = DataKey::PayrollRun(run_id);
+        let mut run: PayrollRun = e
+            .storage()
+            .persistent()
+            .get(&run_key)
+            .expect("Run not found");
+
+        run.reconciliation_status = status;
+        e.storage().persistent().set(&run_key, &run);
+
+        e.events().publish(
+            (
+                symbol_short!("payroll"),
+                Symbol::new(&e, "reconciliation_updated"),
+            ),
+            (run_id, status),
         );
     }
 
@@ -858,10 +886,7 @@ impl Payroll {
         }
         current_admin.require_auth();
 
-        if e.storage()
-            .persistent()
-            .has(&DataKey::PendingAdminRotation)
-        {
+        if e.storage().persistent().has(&DataKey::PendingAdminRotation) {
             panic!("A pending admin rotation already exists");
         }
 
@@ -929,11 +954,7 @@ impl Payroll {
         }
         current_admin.require_auth();
 
-        if !e
-            .storage()
-            .persistent()
-            .has(&DataKey::PendingAdminRotation)
-        {
+        if !e.storage().persistent().has(&DataKey::PendingAdminRotation) {
             panic!("No pending admin rotation to cancel");
         }
         e.storage()
@@ -941,7 +962,10 @@ impl Payroll {
             .remove(&DataKey::PendingAdminRotation);
 
         e.events().publish(
-            (symbol_short!("payroll"), Symbol::new(&e, "admin_rot_cancel")),
+            (
+                symbol_short!("payroll"),
+                Symbol::new(&e, "admin_rot_cancel"),
+            ),
             current_admin,
         );
     }
@@ -973,15 +997,6 @@ impl Payroll {
         e.storage()
             .persistent()
             .set(&DataKey::PendingTreasuryRotation, &proposal);
-        let run_key = DataKey::PayrollRun(run_id);
-        let mut run: PayrollRun = e
-            .storage()
-            .persistent()
-            .get(&run_key)
-            .expect("Run not found");
-
-        run.reconciliation_status = status;
-        e.storage().persistent().set(&run_key, &run);
 
         e.events().publish(
             (
@@ -1070,9 +1085,7 @@ impl Payroll {
 
     /// Return the pending admin rotation proposal, if any.
     pub fn get_pending_admin_rotation(e: Env) -> Option<PendingRotation> {
-        e.storage()
-            .persistent()
-            .get(&DataKey::PendingAdminRotation)
+        e.storage().persistent().get(&DataKey::PendingAdminRotation)
     }
 
     /// Return the pending treasury-owner rotation proposal, if any.
@@ -1080,11 +1093,6 @@ impl Payroll {
         e.storage()
             .persistent()
             .get(&DataKey::PendingTreasuryRotation)
-    }
-                Symbol::new(&e, "reconciliation_updated"),
-            ),
-            (run_id, status),
-        );
     }
 }
 
@@ -1500,12 +1508,8 @@ mod tests {
         let (payroll_client, admin, _treasury, _treasury_owner, _employee) =
             setup_simple_payroll(&env);
 
-        let id = payroll_client.create_run_draft(
-            &admin,
-            &10_000i128,
-            &20u32,
-            &Symbol::new(&env, "JAN"),
-        );
+        let id =
+            payroll_client.create_run_draft(&admin, &10_000i128, &20u32, &Symbol::new(&env, "JAN"));
         let draft = payroll_client.get_run_draft(&id);
 
         assert_eq!(draft.state, RunDraftState::Pending);
@@ -1520,12 +1524,8 @@ mod tests {
         let (payroll_client, admin, _treasury, _treasury_owner, _employee) =
             setup_simple_payroll(&env);
 
-        let id = payroll_client.create_run_draft(
-            &admin,
-            &10_000i128,
-            &20u32,
-            &Symbol::new(&env, "FEB"),
-        );
+        let id =
+            payroll_client.create_run_draft(&admin, &10_000i128, &20u32, &Symbol::new(&env, "FEB"));
         payroll_client.amend_run_draft(&admin, &id, &12_000i128, &22u32);
 
         let draft = payroll_client.get_run_draft(&id);
@@ -1541,12 +1541,8 @@ mod tests {
         let (payroll_client, admin, _treasury, _treasury_owner, _employee) =
             setup_simple_payroll(&env);
 
-        let id = payroll_client.create_run_draft(
-            &admin,
-            &8_000i128,
-            &15u32,
-            &Symbol::new(&env, "MAR"),
-        );
+        let id =
+            payroll_client.create_run_draft(&admin, &8_000i128, &15u32, &Symbol::new(&env, "MAR"));
         payroll_client.finalize_run_draft(&admin, &id);
 
         let draft = payroll_client.get_run_draft(&id);
@@ -1559,15 +1555,14 @@ mod tests {
         let (payroll_client, admin, _treasury, _treasury_owner, _employee) =
             setup_simple_payroll(&env);
 
-        let id = payroll_client.create_run_draft(
-            &admin,
-            &5_000i128,
-            &10u32,
-            &Symbol::new(&env, "APR"),
-        );
+        let id =
+            payroll_client.create_run_draft(&admin, &5_000i128, &10u32, &Symbol::new(&env, "APR"));
         payroll_client.finalize_run_draft(&admin, &id);
 
         let result = payroll_client.try_amend_run_draft(&admin, &id, &9_000i128, &18u32);
+        assert!(result.is_err());
+    }
+
     // ── Issue #103: per-payroll run nonce uniqueness ───────────────────────────
 
     #[test]
@@ -1708,12 +1703,7 @@ mod tests {
             setup_simple_payroll(&env);
 
         let attacker = Address::generate(&env);
-        payroll_client.create_run_draft(
-            &attacker,
-            &1_000i128,
-            &1u32,
-            &Symbol::new(&env, "MAY"),
-        );
+        payroll_client.create_run_draft(&attacker, &1_000i128, &1u32, &Symbol::new(&env, "MAY"));
     }
 
     // ── Issue #91: admin/treasury rotation ───────────────────────────────────
@@ -1778,7 +1768,6 @@ mod tests {
     }
 
     #[test]
-    fn test_treasury_rotation_full_flow() {
     fn test_batch_runs_without_draft_hash() {
         let env = Env::default();
         let (payroll_client, _admin, _treasury, _treasury_owner, employee) =
@@ -1877,8 +1866,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "A pending emergency request already exists")]
-    fn test_duplicate_emergency_request_rejected() {
+    fn test_treasury_rotation_full_flow() {
         let env = Env::default();
         let (payroll_client, _admin, _treasury, treasury_owner, _employee) =
             setup_simple_payroll(&env);
@@ -1908,11 +1896,28 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "A pending admin rotation already exists")]
-    fn test_duplicate_admin_rotation_proposal_rejected() {
+    #[should_panic(expected = "A pending emergency request already exists")]
+    fn test_duplicate_emergency_request_rejected() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
         let recipient = Address::generate(&env);
         payroll_client.request_emergency_withdrawal(&treasury_owner, &100i128, &recipient);
         payroll_client.request_emergency_withdrawal(&treasury_owner, &200i128, &recipient);
+    }
+
+    #[test]
+    #[should_panic(expected = "A pending admin rotation already exists")]
+    fn test_duplicate_admin_rotation_proposal_rejected() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        let new_admin1 = Address::generate(&env);
+        payroll_client.propose_admin_rotation(&admin, &new_admin1);
+        let new_admin2 = Address::generate(&env);
+        payroll_client.propose_admin_rotation(&admin, &new_admin2);
     }
 
     // ── Issue #134: reconciliation status tracking ─────────────────────────────

--- a/contracts/payroll_registry/README.md
+++ b/contracts/payroll_registry/README.md
@@ -35,7 +35,8 @@ The `CompanyInfo` struct definition in Rust:
 
 ## Notes
 
-- Company IDs are allocated sequentially and persisted with `DataKey::NextCompanyId`.
+- Company IDs are allocated sequentially and persisted with `DataKey::CompanySequence`.
+- Duplicate company registration for the same admin address is rejected with `"Company already registered"`.
 - Admin-gated methods load `CompanyInfo` via `DataKey::Company(company_id)` and call
   `info.admin.require_auth()` before mutating employee state.
 

--- a/contracts/payroll_registry/src/lib.rs
+++ b/contracts/payroll_registry/src/lib.rs
@@ -102,12 +102,7 @@ pub trait PayrollRegistryTrait {
 
     /// Set the eligibility status for a registered employee.
     /// Requires authorisation from the company admin.
-    fn set_employee_status(
-        env: Env,
-        company_id: u64,
-        employee: Address,
-        status: EmployeeStatus,
-    );
+    fn set_employee_status(env: Env, company_id: u64, employee: Address, status: EmployeeStatus);
 
     /// Return the eligibility status of an employee.
     /// Returns `Incomplete` if no explicit status has been set.
@@ -119,7 +114,12 @@ pub trait PayrollRegistryTrait {
     // ── Issue #91: company-level admin/treasury rotation ─────────────────────
 
     /// Propose a new company admin (step 1 of 2).
-    fn propose_admin_rotation(env: Env, company_id: u64, current_admin: Address, new_admin: Address);
+    fn propose_admin_rotation(
+        env: Env,
+        company_id: u64,
+        current_admin: Address,
+        new_admin: Address,
+    );
 
     /// Accept a pending admin rotation (step 2 of 2).
     fn accept_admin_rotation(env: Env, company_id: u64, new_admin: Address);
@@ -280,12 +280,7 @@ impl PayrollRegistryTrait for PayrollRegistry {
 
     // ── Issue #90: employee eligibility ──────────────────────────────────────
 
-    fn set_employee_status(
-        env: Env,
-        company_id: u64,
-        employee: Address,
-        status: EmployeeStatus,
-    ) {
+    fn set_employee_status(env: Env, company_id: u64, employee: Address, status: EmployeeStatus) {
         let info: CompanyInfo = env
             .storage()
             .persistent()

--- a/contracts/payroll_registry/src/lib.rs
+++ b/contracts/payroll_registry/src/lib.rs
@@ -66,6 +66,8 @@ pub enum DataKey {
     PendingAdminRotation(u64),
     /// Pending treasury rotation for a company (issue #91).
     PendingTreasuryRotation(u64),
+    /// Per-admin company ID lookup (issue #152: reject duplicate company registration).
+    CompanyAdmin(Address),
 }
 
 // ---------------------------------------------------------------------------
@@ -149,6 +151,14 @@ impl PayrollRegistryTrait for PayrollRegistry {
     fn register_company(env: Env, admin: Address, treasury: Address) -> u64 {
         admin.require_auth();
 
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::CompanyAdmin(admin.clone()))
+        {
+            panic!("Company already registered");
+        }
+
         let id: u64 = env
             .storage()
             .persistent()
@@ -165,6 +175,9 @@ impl PayrollRegistryTrait for PayrollRegistry {
             treasury: treasury.clone(),
         };
         env.storage().persistent().set(&DataKey::Company(id), &info);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CompanyAdmin(admin.clone()), &id);
 
         env.events().publish(
             (Symbol::new(&env, "CompanyRegistered"), id),
@@ -188,14 +201,13 @@ impl PayrollRegistryTrait for PayrollRegistry {
         let emp = employee.clone();
         env.storage()
             .persistent()
-            .set(&DataKey::Employee(company_id, employee.clone()), &commitment);
+            .set(&DataKey::Employee(company_id, emp.clone()), &commitment);
 
         // Default status for newly registered employees is Active (issue #90).
         env.storage().persistent().set(
-            &DataKey::EmpStatus(company_id, employee),
+            &DataKey::EmpStatus(company_id, emp),
             &EmployeeStatus::Active,
         );
-            .set(&DataKey::Employee(company_id, emp), &commitment);
 
         env.events().publish(
             (Symbol::new(&env, "EmployeeAdded"), company_id, employee),
@@ -371,13 +383,21 @@ impl PayrollRegistryTrait for PayrollRegistry {
             .get(&DataKey::Company(company_id))
             .expect("Company not found");
 
-        info.admin = new_admin;
+        let old_admin = info.admin.clone();
+
+        info.admin = new_admin.clone();
         env.storage()
             .persistent()
             .set(&DataKey::Company(company_id), &info);
         env.storage()
             .persistent()
             .remove(&DataKey::PendingAdminRotation(company_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::CompanyAdmin(old_admin));
+        env.storage()
+            .persistent()
+            .set(&DataKey::CompanyAdmin(new_admin), &company_id);
     }
 
     fn cancel_admin_rotation(env: Env, company_id: u64, current_admin: Address) {

--- a/contracts/payroll_registry/src/tests.rs
+++ b/contracts/payroll_registry/src/tests.rs
@@ -19,11 +19,12 @@ fn setup_no_auth_mock() -> (Env, Address) {
 fn test_register_company_returns_sequential_ids() {
     let (env, contract_id) = setup();
     let client = PayrollRegistryClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
+    let admin0 = Address::generate(&env);
+    let admin1 = Address::generate(&env);
     let treasury = Address::generate(&env);
 
-    let id0 = client.register_company(&admin, &treasury);
-    let id1 = client.register_company(&admin, &treasury);
+    let id0 = client.register_company(&admin0, &treasury);
+    let id1 = client.register_company(&admin1, &treasury);
 
     assert_eq!(id0, 0u64);
     assert_eq!(id1, 1u64);
@@ -44,11 +45,12 @@ fn test_register_company_requires_admin_auth() {
 fn test_register_company_updates_company_sequence() {
     let (env, contract_id) = setup();
     let client = PayrollRegistryClient::new(&env, &contract_id);
-    let admin = Address::generate(&env);
+    let admin0 = Address::generate(&env);
+    let admin1 = Address::generate(&env);
     let treasury = Address::generate(&env);
 
-    client.register_company(&admin, &treasury);
-    client.register_company(&admin, &treasury);
+    client.register_company(&admin0, &treasury);
+    client.register_company(&admin1, &treasury);
 
     let seq: u64 = env.as_contract(&contract_id, || {
         env.storage()
@@ -236,12 +238,6 @@ fn test_get_commitment_returns_employee_commitment() {
 
 #[test]
 fn test_add_employee_sets_active_status() {
-// ---------------------------------------------------------------------------
-// Event emission tests
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_register_company_emits_event() {
     let (env, contract_id) = setup();
     let client = PayrollRegistryClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
@@ -261,22 +257,6 @@ fn test_register_company_emits_event() {
 
 #[test]
 fn test_set_employee_status_inactive_makes_ineligible() {
-
-    let before = env.events().all().len();
-    let company_id = client.register_company(&admin, &treasury);
-    let after = env.events().all().len();
-    assert_eq!(after, before + 1);
-
-    let event = env.events().all().get(after - 1).unwrap();
-    assert_eq!(event.1.len(), 2);
-    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
-    assert_eq!(sym0, Symbol::new(&env, "CompanyRegistered"));
-    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
-    assert_eq!(comp_id, company_id);
-}
-
-#[test]
-fn test_add_employee_emits_event() {
     let (env, contract_id) = setup();
     let client = PayrollRegistryClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
@@ -298,26 +278,6 @@ fn test_add_employee_emits_event() {
 
 #[test]
 fn test_set_employee_status_incomplete_makes_ineligible() {
-    let commitment = BytesN::from_array(&env, &[1u8; 32]);
-
-    let company_id = client.register_company(&admin, &treasury);
-    let before = env.events().all().len();
-    client.add_employee(&company_id, &employee, &commitment);
-    let after = env.events().all().len();
-    assert_eq!(after, before + 1);
-
-    let event = env.events().all().get(after - 1).unwrap();
-    assert_eq!(event.1.len(), 3);
-    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
-    assert_eq!(sym0, Symbol::new(&env, "EmployeeAdded"));
-    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
-    assert_eq!(comp_id, company_id);
-    let emp_addr: Address = event.1.get(2).unwrap().try_into_val(&env.clone()).unwrap();
-    assert_eq!(emp_addr, employee);
-}
-
-#[test]
-fn test_remove_employee_emits_event() {
     let (env, contract_id) = setup();
     let client = PayrollRegistryClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
@@ -348,7 +308,79 @@ fn test_unregistered_employee_is_not_eligible() {
 
 #[test]
 fn test_reactivating_inactive_employee_restores_eligibility() {
-    let commitment = BytesN::from_array(&env, &[2u8; 32]);
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let commitment = BytesN::from_array(&env, &[4u8; 32]);
+
+    let company_id = client.register_company(&admin, &treasury);
+    client.add_employee(&company_id, &employee, &commitment);
+    client.set_employee_status(&company_id, &employee, &EmployeeStatus::Inactive);
+    assert!(!client.is_eligible(&company_id, &employee));
+
+    client.set_employee_status(&company_id, &employee, &EmployeeStatus::Active);
+    assert!(client.is_eligible(&company_id, &employee));
+}
+
+// ---------------------------------------------------------------------------
+// Event emission tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_register_company_emits_event() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let before = env.events().all().len();
+    let company_id = client.register_company(&admin, &treasury);
+    let after = env.events().all().len();
+    assert_eq!(after, before + 1);
+
+    let event = env.events().all().get(after - 1).unwrap();
+    assert_eq!(event.1.len(), 2);
+    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(sym0, Symbol::new(&env, "CompanyRegistered"));
+    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(comp_id, company_id);
+}
+
+#[test]
+fn test_add_employee_emits_event() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let commitment = BytesN::from_array(&env, &[1u8; 32]);
+
+    let company_id = client.register_company(&admin, &treasury);
+    let before = env.events().all().len();
+    client.add_employee(&company_id, &employee, &commitment);
+    let after = env.events().all().len();
+    assert_eq!(after, before + 1);
+
+    let event = env.events().all().get(after - 1).unwrap();
+    assert_eq!(event.1.len(), 3);
+    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(sym0, Symbol::new(&env, "EmployeeAdded"));
+    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(comp_id, company_id);
+    let emp_addr: Address = event.1.get(2).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(emp_addr, employee);
+}
+
+#[test]
+fn test_remove_employee_emits_event() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let commitment = BytesN::from_array(&env, &[1u8; 32]);
 
     let company_id = client.register_company(&admin, &treasury);
     client.add_employee(&company_id, &employee, &commitment);
@@ -374,15 +406,24 @@ fn test_update_commitment_emits_event() {
     let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
     let employee = Address::generate(&env);
-    let commitment = BytesN::from_array(&env, &[4u8; 32]);
+    let old_commitment = BytesN::from_array(&env, &[1u8; 32]);
+    let new_commitment = BytesN::from_array(&env, &[9u8; 32]);
 
     let company_id = client.register_company(&admin, &treasury);
-    client.add_employee(&company_id, &employee, &commitment);
-    client.set_employee_status(&company_id, &employee, &EmployeeStatus::Inactive);
-    assert!(!client.is_eligible(&company_id, &employee));
+    client.add_employee(&company_id, &employee, &old_commitment);
+    let before = env.events().all().len();
+    client.update_commitment(&company_id, &employee, &new_commitment);
+    let after = env.events().all().len();
+    assert_eq!(after, before + 1);
 
-    client.set_employee_status(&company_id, &employee, &EmployeeStatus::Active);
-    assert!(client.is_eligible(&company_id, &employee));
+    let event = env.events().all().get(after - 1).unwrap();
+    assert_eq!(event.1.len(), 3);
+    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(sym0, Symbol::new(&env, "CommitmentUpdated"));
+    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(comp_id, company_id);
+    let emp_addr: Address = event.1.get(2).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(emp_addr, employee);
 }
 
 // ── Issue #91: company admin/treasury rotation ────────────────────────────────
@@ -483,22 +524,35 @@ fn test_duplicate_admin_rotation_proposal_rejected() {
 
     client.propose_admin_rotation(&company_id, &admin, &new_admin);
     client.propose_admin_rotation(&company_id, &admin, &new_admin);
-    let old_commitment = BytesN::from_array(&env, &[1u8; 32]);
-    let new_commitment = BytesN::from_array(&env, &[9u8; 32]);
+}
 
-    let company_id = client.register_company(&admin, &treasury);
-    client.add_employee(&company_id, &employee, &old_commitment);
-    let before = env.events().all().len();
-    client.update_commitment(&company_id, &employee, &new_commitment);
-    let after = env.events().all().len();
-    assert_eq!(after, before + 1);
+// ── Issue #152: Duplicate company registration rejection tests ───────────────
 
-    let event = env.events().all().get(after - 1).unwrap();
-    assert_eq!(event.1.len(), 3);
-    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
-    assert_eq!(sym0, Symbol::new(&env, "CommitmentUpdated"));
-    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
-    assert_eq!(comp_id, company_id);
-    let emp_addr: Address = event.1.get(2).unwrap().try_into_val(&env.clone()).unwrap();
-    assert_eq!(emp_addr, employee);
+#[test]
+fn test_register_company_duplicate_registration_fails() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    // First registration should succeed
+    let id0 = client.register_company(&admin, &treasury);
+    assert_eq!(id0, 0u64);
+
+    // Second registration with the same admin must be rejected
+    let result = client.try_register_company(&admin, &treasury);
+    assert!(result.is_err());
+}
+
+#[test]
+#[should_panic(expected = "Company already registered")]
+fn test_register_company_duplicate_registration_panics() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.register_company(&admin, &treasury);
+    // Duplicate registration panics
+    client.register_company(&admin, &treasury);
 }

--- a/docs/security-review-checklist.md
+++ b/docs/security-review-checklist.md
@@ -102,9 +102,9 @@ This checklist **must be completed** before any mainnet-style deployment of ZK P
   - *Test:* `test_commitment_overwrite_rejected` in `salary_commitment/src/tests.rs`
   - *Expected:* Second `set_commitment()` call for same employee returns error.
 
-- [ ] **Company registration is idempotent** — Registering the same company twice does not break state.
-  - *Test:* `test_register_company_twice()` in `payroll_registry/src/tests.rs`
-  - *Expected:* Second registration either returns same company ID or an error, never corrupt state.
+- [x] **Company registration duplicate check** — Registering duplicate companies for the same admin is rejected.
+  - *Test:* `test_register_company_duplicate_registration_fails()` & `test_register_company_duplicate_registration_panics()` in `payroll_registry/src/tests.rs`
+  - *Expected:* Second registration with the same admin address returns an error / panics.
 
 - [ ] **Nullifier mapping is consistent** — Each proof's nullifier maps to exactly one verified payment.
   - *Check:* Review `payment_executor::process_payment()` nullifier insertion logic.


### PR DESCRIPTION
# test(payroll_registry): add duplicate company registration rejection tests (#152)

## Summary

This PR adds contract logic and unit tests to verify that duplicate company registration for the same admin address is rejected by the `payroll_registry` contract.

Closes #152

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] ZK circuit change (requires new trusted setup / ptau ceremony)
- [ ] Refactor (no functional changes)
- [ ] Documentation / comments only
- [ ] CI/CD or tooling change

## Description of Changes

- Added `DataKey::CompanyAdmin(Address)` storage slot in `contracts/payroll_registry/src/lib.rs` to map admin addresses to company IDs.
- Updated `register_company()` to check if an admin address is already registered and panic with `"Company already registered"` on duplicates.
- Updated `accept_admin_rotation()` to transfer `CompanyAdmin` tracking from the previous admin to the new admin.
- Added tests `test_register_company_duplicate_registration_fails` and `test_register_company_duplicate_registration_panics` in `contracts/payroll_registry/src/tests.rs`.
- Updated existing sequential ID and company sequence tests to use unique admin keypairs per company registration.
- Updated `contracts/payroll_registry/README.md` and `docs/security-review-checklist.md` to document duplicate company registration rejection behavior.

---

## Checklist

### General

- [x] My code follows the project's Rust style guidelines (`cargo fmt --check` passes)
- [x] I have performed a self-review of my own code
- [x] I have added comments for any non-obvious logic
- [x] I have updated relevant documentation (`README.md`, `CONTRIBUTING.md`, inline docs)
- [x] My changes do not introduce new compiler warnings (`cargo clippy` passes)
- [x] I have added tests that cover my changes
- [x] All existing tests pass locally (`cargo test`)

### Smart Contracts (if applicable)

- [ ] I have measured and documented gas / resource usage for new or changed entry-points
  - CPU instructions (before / after):
  - Memory bytes (before / after):
  - Ledger entries read/written (before / after):
  - Estimated XLM fee (before / after):
- [x] I have verified there are no storage layout regressions (state rent impact assessed)
- [x] I have checked for integer overflow / underflow and used checked arithmetic
- [x] Authorization checks (`require_auth`, `require_auth_for_args`) are correct and tested
- [x] No sensitive data (salaries, blinding factors, private keys) is emitted in events or exposed in storage

### ZK Circuits (if applicable)

- [ ] Circuit compiles without errors: `circom <circuit>.circom --r1cs --wasm --sym`
- [ ] Witness generation succeeds for test inputs
- [ ] Proof generation and verification pass end-to-end
- [ ] New trusted setup (phase 2 ptau) is required: **Yes / No**
  - If yes, link to the ceremony artifacts:
- [ ] Constraint count change documented:
  - Before: <!-- n constraints -->
  - After:  <!-- n constraints -->
- [ ] Verifier Solidity/Rust contract regenerated (if verifying key changed)

### Security

- [x] I have considered potential attack vectors relevant to this change
  - [x] Re-entrancy (not applicable on Soroban, but noted for audit completeness)
  - [x] Front-running / MEV risks
  - [x] Proof malleability (for ZK changes)
  - [x] Commitment binding / hiding properties preserved (for commitment changes)
- [x] No hardcoded secrets, keys, or sensitive configuration values in code
- [x] Dependencies added/updated have been reviewed for known vulnerabilities (`cargo audit`)

---

## Testing Evidence

