### PR TITLE
test(audit_module): add high-priority audit grant revocation tests

### DIFF
--- a/contracts/audit_module/src/tests.rs
+++ b/contracts/audit_module/src/tests.rs
@@ -602,3 +602,219 @@ fn test_export_audit_summary_emits_event() {
 
     assert!(env.events().all().len() > before);
 }
+
+// ── Issue #172: revoked audit grants cannot read/export/validate audit data ──
+//
+// These tests confirm that once `revoke_view_key` succeeds, every
+// authorize_auditor-gated entry point rejects the former auditor with
+// `AuditError::KeyNotFound` — the same failure mode as an auditor who was
+// never granted a key. This is the property compliance relies on: revocation
+// must immediately and completely cut off access to restricted audit data,
+// with no operation left that still honors the stale grant.
+
+fn make_commitment(env: &Env, amount: i128, blinding: &BytesN<32>) -> BytesN<32> {
+    let mut preimage = soroban_sdk::Bytes::new(env);
+    preimage.extend_from_array(&amount.to_le_bytes());
+    let blinding_slice: [u8; 32] = blinding.into();
+    preimage.extend_from_array(&blinding_slice);
+    env.crypto().sha256(&preimage).into()
+}
+
+#[test]
+fn test_revoked_key_cannot_validate_commitment_with_key() {
+    let (env, contract_id) = setup();
+    let client = AuditModuleClient::new(&env, &contract_id);
+
+    let auditor = soroban_sdk::Address::generate(&env);
+    let seq = env.ledger().sequence();
+    client.generate_view_key(&auditor, &(seq + 1_000));
+
+    let amount: i128 = 100_000;
+    let blinding = BytesN::from_array(&env, &[0x21; 32]);
+    let stored = make_commitment(&env, amount, &blinding);
+
+    // Sanity check: verification succeeds while the grant is live.
+    assert!(client.verify_commitment_with_key(
+        &auditor,
+        &stored,
+        &amount,
+        &blinding,
+        &AuditScope::EmployeeList
+    ));
+
+    let admin = contract_id.clone();
+    client.revoke_view_key(&admin, &auditor);
+
+    let result = client.try_verify_commitment_with_key(
+        &auditor,
+        &stored,
+        &amount,
+        &blinding,
+        &AuditScope::EmployeeList,
+    );
+    assert_eq!(result.unwrap_err().unwrap(), AuditError::KeyNotFound);
+}
+
+#[test]
+fn test_revoked_key_cannot_validate_commitment_with_supplied_view_key() {
+    let (env, contract_id) = setup();
+    let client = AuditModuleClient::new(&env, &contract_id);
+
+    let auditor = soroban_sdk::Address::generate(&env);
+    let seq = env.ledger().sequence();
+    let key = client.generate_view_key(&auditor, &(seq + 1_000));
+
+    let amount: i128 = 120_000;
+    let blinding = BytesN::from_array(&env, &[0x22; 32]);
+    let stored = make_commitment(&env, amount, &blinding);
+
+    // Sanity check: verification succeeds while the grant is live.
+    assert!(client.verify_commitment_with_view_key(
+        &auditor,
+        &key,
+        &stored,
+        &amount,
+        &blinding,
+        &AuditScope::EmployeeList
+    ));
+
+    let admin = contract_id.clone();
+    client.revoke_view_key(&admin, &auditor);
+
+    // Even presenting the still-known key bytes must fail, since the
+    // underlying grant record no longer exists.
+    let result = client.try_verify_commitment_with_view_key(
+        &auditor,
+        &key,
+        &stored,
+        &amount,
+        &blinding,
+        &AuditScope::EmployeeList,
+    );
+    assert_eq!(result.unwrap_err().unwrap(), AuditError::KeyNotFound);
+}
+
+#[test]
+fn test_revoked_key_cannot_generate_aggregate_report() {
+    let (env, contract_id) = setup();
+    let client = AuditModuleClient::new(&env, &contract_id);
+
+    let auditor = soroban_sdk::Address::generate(&env);
+    let seq = env.ledger().sequence();
+    client.generate_view_key(&auditor, &(seq + 1_000));
+
+    let company_id = Symbol::new(&env, "ACME");
+    let now = env.ledger().timestamp();
+
+    // Sanity check: report generation succeeds while the grant is live.
+    assert!(client
+        .try_generate_aggregate_report(&auditor, &company_id, &now, &(now + 86_400))
+        .is_ok());
+
+    let admin = contract_id.clone();
+    client.revoke_view_key(&admin, &auditor);
+
+    let result =
+        client.try_generate_aggregate_report(&auditor, &company_id, &now, &(now + 86_400));
+    assert_eq!(result.unwrap_err().unwrap(), AuditError::KeyNotFound);
+}
+
+#[test]
+fn test_revoked_key_cannot_export_audit_summary() {
+    let (env, contract_id) = setup();
+    let client = AuditModuleClient::new(&env, &contract_id);
+
+    let auditor = soroban_sdk::Address::generate(&env);
+    let seq = env.ledger().sequence();
+    client.generate_view_key(&auditor, &(seq + 1_000));
+
+    let company_id = Symbol::new(&env, "default");
+    let ts = env.ledger().timestamp();
+
+    // Sanity check: export succeeds while the grant is live.
+    assert!(client
+        .try_export_audit_summary(&auditor, &company_id, &0u64, &(ts + 1_000))
+        .is_ok());
+
+    let admin = contract_id.clone();
+    client.revoke_view_key(&admin, &auditor);
+
+    let result = client.try_export_audit_summary(&auditor, &company_id, &0u64, &(ts + 1_000));
+    assert_eq!(result.unwrap_err().unwrap(), AuditError::KeyNotFound);
+}
+
+#[test]
+fn test_revoked_key_cannot_read_view_key_record() {
+    let (env, contract_id) = setup();
+    let client = AuditModuleClient::new(&env, &contract_id);
+
+    let auditor = soroban_sdk::Address::generate(&env);
+    let seq = env.ledger().sequence();
+    client.generate_view_key(&auditor, &(seq + 1_000));
+
+    let admin = contract_id.clone();
+    client.revoke_view_key(&admin, &auditor);
+
+    let result = client.try_get_view_key(&auditor);
+    assert_eq!(result.unwrap_err().unwrap(), AuditError::KeyNotFound);
+}
+
+#[test]
+fn test_revocation_does_not_affect_other_auditors() {
+    let (env, contract_id) = setup();
+    let client = AuditModuleClient::new(&env, &contract_id);
+
+    let revoked_auditor = soroban_sdk::Address::generate(&env);
+    let active_auditor = soroban_sdk::Address::generate(&env);
+    let seq = env.ledger().sequence();
+    client.generate_view_key(&revoked_auditor, &(seq + 1_000));
+    client.generate_view_key(&active_auditor, &(seq + 1_000));
+
+    let admin = contract_id.clone();
+    client.revoke_view_key(&admin, &revoked_auditor);
+
+    // The revoked auditor loses access...
+    assert!(!client.verify_access(&revoked_auditor));
+    assert!(client.try_get_view_key(&revoked_auditor).is_err());
+
+    // ...but an unrelated auditor's grant must remain fully intact.
+    assert!(client.verify_access(&active_auditor));
+
+    let company_id = Symbol::new(&env, "ACME");
+    let now = env.ledger().timestamp();
+    assert!(client
+        .try_generate_aggregate_report(&active_auditor, &company_id, &now, &(now + 86_400))
+        .is_ok());
+}
+
+#[test]
+fn test_revoke_then_regrant_restores_access() {
+    let (env, contract_id) = setup();
+    let client = AuditModuleClient::new(&env, &contract_id);
+
+    let auditor = soroban_sdk::Address::generate(&env);
+    let seq = env.ledger().sequence();
+    client.generate_view_key(&auditor, &(seq + 1_000));
+
+    let admin = contract_id.clone();
+    client.revoke_view_key(&admin, &auditor);
+    assert!(!client.verify_access(&auditor));
+
+    // Issuing a fresh grant after revocation must restore access — a stale
+    // revocation must not permanently lock the auditor out.
+    let new_key = client.generate_view_key(&auditor, &(seq + 2_000));
+    assert!(client.verify_access(&auditor));
+
+    let amount: i128 = 33_000;
+    let blinding = BytesN::from_array(&env, &[0x33; 32]);
+    let stored = make_commitment(&env, amount, &blinding);
+
+    assert!(client.verify_commitment_with_view_key(
+        &auditor,
+        &new_key,
+        &stored,
+        &amount,
+        &blinding,
+        &AuditScope::EmployeeList
+    ));
+}


### PR DESCRIPTION
## Summary
- Adds 7 tests to `contracts/audit_module/src/tests.rs` proving that once an auditor's view key is revoked via `revoke_view_key`, every `authorize_auditor`-gated entry point rejects them with `AuditError::KeyNotFound`:
  - `verify_commitment_with_key`
  - `verify_commitment_with_view_key` (even when the stale key bytes are still known)
  - `generate_aggregate_report`
  - `export_audit_summary`
  - `get_view_key`
- Also covers two related reliability properties: revoking one auditor doesn't affect another auditor's active grant, and re-granting a key after revocation correctly restores access.

Closes #172

## Test plan
- [x] `cargo test -p audit_module` — all 7 new tests pass
- [x] Verified via `git stash` that the one pre-existing unrelated failure (`test_export_audit_summary_returns_correct_counts`) also fails on `main` without this change, confirming it's not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)