### PR TITLE
fix(payment_executor): reject duplicate active payroll periods

### DIFF
--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -219,6 +219,19 @@ impl PaymentExecutor {
             return Err(PaymentError::PeriodAlreadyExists);
         }
 
+        if next_id > 1 {
+            let prev_key = DataKey::Period(company_id, next_id - 1);
+            if let Some(prev_period) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, PayrollPeriod>(&prev_key)
+            {
+                if !prev_period.closed {
+                    return Err(PaymentError::PeriodAlreadyExists);
+                }
+            }
+        }
+
         let period = PayrollPeriod {
             period_id: next_id,
             company_id,
@@ -749,6 +762,27 @@ mod tests {
         assert_eq!(result.company_id, company_id);
         assert!(!result.closed);
         assert_eq!(result.payment_count, 0);
+    }
+
+    #[test]
+    fn test_duplicate_period_creation_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, PaymentExecutor);
+        let client = PaymentExecutorClient::new(&env, &contract_id);
+
+        let addresses = setup_addresses(&env);
+        client.initialize(&addresses);
+
+        let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let company_id = registry_client.register_company(&admin, &treasury);
+
+        let _ = client.create_period(&company_id);
+
+        let result = client.try_create_period(&company_id);
+        assert_eq!(result.unwrap_err().unwrap(), PaymentError::PeriodAlreadyExists);
     }
 
     #[test]

--- a/contracts/payment_executor/tests/amount_boundary_tests.rs
+++ b/contracts/payment_executor/tests/amount_boundary_tests.rs
@@ -208,6 +208,7 @@ fn test_total_paid_overflow_panics_after_treasury_replenishment() {
     // Treasury is now drained to 0; replenishing it and paying again is a
     // legitimate flow that pushes the running total past `i128::MAX`.
     token.mint(&treasury, &100i128);
+    executor.close_period(&company_id, &1);
     executor.create_period(&company_id);
     executor.execute_payment(
         &company_id,
@@ -242,6 +243,7 @@ fn test_precision_preserved_across_multiple_non_round_payments() {
         token.mint(&treasury, &amount);
 
         if i > 0 {
+            executor.close_period(&company_id, &(i as u32));
             executor.create_period(&company_id);
         }
 

--- a/contracts/payment_executor/tests/security_tests.rs
+++ b/contracts/payment_executor/tests/security_tests.rs
@@ -114,6 +114,7 @@ fn test_proof_replay_protection() {
         &1,
     );
 
+    executor.close_period(&company_id, &1);
     executor.create_period(&company_id);
 
     let result = executor.try_execute_payment(
@@ -192,7 +193,7 @@ fn test_reentrancy_state_updates_before_external_calls() {
     let proof_c = BytesN::from_array(&env, &[7u8; 64]);
     let nullifier = BytesN::from_array(&env, &[8u8; 32]);
 
-    executor.create_period(&company_id);
+    executor.close_period(&company_id, &1);
     executor.create_period(&company_id);
 
     executor.execute_payment(
@@ -268,6 +269,7 @@ fn test_retry_across_periods_succeeds_with_new_period() {
     assert_eq!(executor.get_total_paid(&company_id), 500);
 
     // Create a new period (period 2)
+    executor.close_period(&company_id, &1);
     executor.create_period(&company_id);
 
     // Payment 2 in period 2 with different proof/amount
@@ -301,7 +303,7 @@ fn test_retry_across_periods_succeeds_with_new_period() {
         &proof_b_1,
         &proof_c_1,
         &nullifier_1,
-        &1,
+        &2,
     );
     assert_eq!(
         replay_1.unwrap_err().unwrap(),
@@ -419,6 +421,7 @@ fn test_period_isolation_prevents_cross_period_replay() {
     assert!(executor.is_paid(&employee, &1));
 
     // Create a new period (period 2)
+    executor.close_period(&company_id, &1);
     executor.create_period(&company_id);
 
     // Attempt to reuse same proof in period 2 (should fail due to nullifier)


### PR DESCRIPTION
Closes #195

## PR Description

I resolved the issue where multiple active payroll periods could exist concurrently for a company. Previously, the payment executor contract allowed sequential creation of new payroll periods without verifying if the previous one had been closed. This created a loophole where a company could have multiple open periods, complicating reporting, auditability, and reconciliation.

Now, I added logic in the period creation flow to check the status of the previous period. Specifically, when a company requests a new period (with ID `next_id`), if `next_id > 1`, the contract retrieves the previous period record (`next_id - 1`). If the previous period is still open, the transaction fails with `PaymentError::PeriodAlreadyExists`.

This change enforces that at most one active payroll period can exist per company, guaranteeing period isolation and preventing overlapping runs.

## Changes Made
* Modified `contracts/payment_executor/src/lib.rs` to load the previous period in `create_period` and check if it is closed before permitting a new period to be created.
* Added `test_duplicate_period_creation_fails` in `contracts/payment_executor/src/lib.rs` to test the validation rule.
* Updated tests in `contracts/payment_executor/tests/amount_boundary_tests.rs` and `contracts/payment_executor/tests/security_tests.rs` to close the active period before opening a new one.