### PR TITLE
feat(payroll): treasury deposit tracking, archived run queries, company state gate, and docs

### DIFF
--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -145,6 +145,26 @@ pub struct PendingRotation {
     pub proposed_at: u64,
 }
 
+// ── Issue #147: company lifecycle state ──────────────────────────────────────
+
+/// Lifecycle state of the company operating this payroll contract.
+///
+/// Payroll execution is only permitted when the state is `Active`. This gate
+/// runs before any auth checks, balance reads, or transfer logic so that
+/// rejected calls are fully clean with no partial side effects.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompanyState {
+    /// Normal operating state — payroll execution permitted.
+    Active,
+    /// Operations suspended; payroll execution rejected until set to Active.
+    Paused,
+    /// Company decommissioned; no further payroll runs are permitted.
+    Archived,
+    /// Onboarding incomplete; payroll execution not yet permitted.
+    Incomplete,
+}
+
 // ── Storage keys ──────────────────────────────────────────────────────────────
 // Issue #196: Storage Key Versioning Strategy
 //
@@ -256,6 +276,12 @@ pub enum DataKey {
     DraftCommitment(BytesN<32>),
     /// Pending emergency withdrawal request (#104).
     EmergencyRequest,
+    /// Accumulated deposit balance per depositor address (#62).
+    CompanyBalance(Address),
+    /// Marks a completed payroll run as archived for long-term reporting (#146).
+    ArchivedRun(u64),
+    /// Company lifecycle state gate for payroll execution (#147).
+    CompanyState,
     // Future upgrade example (issue #196):
     // PayrollRunV2(u64),  // Would be added here when schema evolution is needed
 }
@@ -304,6 +330,30 @@ impl Payroll {
         }
     }
 
+    // Issue #147: reject payroll execution for any non-Active company state.
+    // Absent state defaults to Active for backward compatibility with existing
+    // deployments that predate this field.
+    fn require_company_active(e: &Env) {
+        if let Some(state) = e
+            .storage()
+            .persistent()
+            .get::<_, CompanyState>(&DataKey::CompanyState)
+        {
+            match state {
+                CompanyState::Active => {}
+                CompanyState::Paused => {
+                    panic!("Company is paused; payroll execution is not permitted")
+                }
+                CompanyState::Archived => {
+                    panic!("Company is archived; payroll execution is not permitted")
+                }
+                CompanyState::Incomplete => {
+                    panic!("Company setup is incomplete; payroll execution is not permitted")
+                }
+            }
+        }
+    }
+
     pub fn set_pause_manager(e: Env, pause_manager: Address) {
         let addrs: ContractAddresses = e
             .storage()
@@ -346,10 +396,32 @@ impl Payroll {
         let token_client = soroban_token::Client::new(&e, &addrs.token);
         token_client.transfer(&from, &addrs.treasury, &amount);
 
+        // Issue #62: accumulate per-depositor balance for auditability.
+        let balance_key = DataKey::CompanyBalance(from.clone());
+        let prev_balance: i128 = e
+            .storage()
+            .persistent()
+            .get(&balance_key)
+            .unwrap_or(0i128);
+        let new_balance = prev_balance + amount;
+        e.storage().persistent().set(&balance_key, &new_balance);
+
         e.events().publish(
             (symbol_short!("payroll"), Symbol::new(&e, "deposit")),
-            (from, amount, deposit_id),
+            (from, amount, deposit_id, new_balance),
         );
+    }
+
+    /// Return the accumulated deposit balance for a given depositor address (#62).
+    ///
+    /// This reflects the running total of all successful deposits made by that
+    /// address. It is an accounting record only; actual treasury liquidity is
+    /// held by the token contract at `ContractAddresses.treasury`.
+    pub fn get_treasury_balance(e: Env, depositor: Address) -> i128 {
+        e.storage()
+            .persistent()
+            .get(&DataKey::CompanyBalance(depositor))
+            .unwrap_or(0i128)
     }
 
     fn derive_run_id(e: &Env) -> u64 {
@@ -804,6 +876,10 @@ impl Payroll {
             .get(&DataKey::Addresses)
             .expect("Not initialized");
 
+        // Issue #147: gate on company lifecycle state before any auth, balance,
+        // or transfer logic runs, so rejected calls produce no partial side effects.
+        Self::require_company_active(&e);
+
         if e.storage().persistent().has(&DataKey::PauseManager) {
             let pm_addr: Address = e
                 .storage()
@@ -823,9 +899,20 @@ impl Payroll {
         // #103 — mark nonce as consumed (store run_id for auditability).
         e.storage().persistent().set(&nonce_key, &run_id);
 
+        let token_client = soroban_token::Client::new(&e, &addrs.token);
+
+        // Issue #62: fail early if the treasury token balance cannot cover the
+        // full batch payout, before any proof verification or transfers begin.
+        let treasury_balance = token_client.balance(&addrs.treasury);
+        if treasury_balance < expected_total_spend {
+            panic!(
+                "Insufficient treasury balance: available {} but batch requires {}",
+                treasury_balance, expected_total_spend
+            );
+        }
+
         let verifier = ProofVerifierClient::new(&e, &addrs.verifier);
         let commitment_client = SalaryCommitmentContractClient::new(&e, &addrs.commitment);
-        let token_client = soroban_token::Client::new(&e, &addrs.token);
 
         for i in 0..count {
             let proof = proofs.get(i).unwrap();
@@ -1337,6 +1424,106 @@ impl Payroll {
             .get(&DataKey::PayrollRun(run_id))
             .expect("Run not found");
         run.metadata_hash == expected_hash
+    }
+
+    // ── Issue #147: company state management ─────────────────────────────────
+
+    /// Set the company lifecycle state.
+    ///
+    /// Only the admin may call. After setting to anything other than `Active`,
+    /// all subsequent `batch_process_payroll` calls will be rejected with a
+    /// descriptive error until the state is restored to `Active`.
+    pub fn set_company_state(e: Env, admin: Address, state: CompanyState) {
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+        e.storage()
+            .persistent()
+            .set(&DataKey::CompanyState, &state);
+        e.events().publish(
+            (symbol_short!("payroll"), Symbol::new(&e, "state_changed")),
+            state,
+        );
+    }
+
+    /// Return the current company state. Returns `Active` if no state has been
+    /// explicitly set (backward-compatible default).
+    pub fn get_company_state(e: Env) -> CompanyState {
+        e.storage()
+            .persistent()
+            .get(&DataKey::CompanyState)
+            .unwrap_or(CompanyState::Active)
+    }
+
+    // ── Issue #146: archived payroll run queries ──────────────────────────────
+
+    /// Mark a completed payroll run as archived for long-term reporting.
+    ///
+    /// Only the admin may archive. Archiving is additive and read-only: it
+    /// flags the run without altering the underlying `PayrollRun` record,
+    /// cannot trigger execution, state transitions, or treasury mutations.
+    pub fn archive_payroll_run(e: Env, admin: Address, run_id: u64) {
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+
+        // Ensure the run exists before archiving it.
+        if !e
+            .storage()
+            .persistent()
+            .has(&DataKey::PayrollRun(run_id))
+        {
+            panic!("Run not found");
+        }
+
+        let archive_key = DataKey::ArchivedRun(run_id);
+        if e.storage().persistent().has(&archive_key) {
+            panic!("Run is already archived");
+        }
+        e.storage().persistent().set(&archive_key, &true);
+
+        e.events().publish(
+            (symbol_short!("payroll"), Symbol::new(&e, "run_archived")),
+            run_id,
+        );
+    }
+
+    /// Return a payroll run only if it has been explicitly archived.
+    ///
+    /// This is the dedicated archived-query path: it is fully read-only and
+    /// panics for runs that exist but have not been archived, keeping the
+    /// archived and active access paths clearly separated.
+    pub fn get_archived_run(e: Env, run_id: u64) -> PayrollRun {
+        if !e
+            .storage()
+            .persistent()
+            .has(&DataKey::ArchivedRun(run_id))
+        {
+            panic!("Run is not archived");
+        }
+        e.storage()
+            .persistent()
+            .get(&DataKey::PayrollRun(run_id))
+            .expect("Run not found")
+    }
+
+    /// Return `true` if the run has been marked as archived, `false` otherwise.
+    pub fn is_run_archived(e: Env, run_id: u64) -> bool {
+        e.storage()
+            .persistent()
+            .has(&DataKey::ArchivedRun(run_id))
     }
 }
 
@@ -3155,5 +3342,260 @@ mod tests {
 
         let attacker = Address::generate(&env);
         payroll_client.set_run_metadata(&attacker, &run_id, &meta_hash);
+    }
+
+    // ── Issue #62: treasury deposit and balance accounting ────────────────────
+
+    #[test]
+    fn test_deposit_increments_company_balance() {
+        let env = Env::default();
+        let (payroll_client, _admin, treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        assert_eq!(payroll_client.get_treasury_balance(&treasury), 0i128);
+
+        let id1 = BytesN::from_array(&env, &[0xb1u8; 32]);
+        payroll_client.deposit(&treasury, &300i128, &id1);
+        assert_eq!(payroll_client.get_treasury_balance(&treasury), 300i128);
+
+        let id2 = BytesN::from_array(&env, &[0xb2u8; 32]);
+        payroll_client.deposit(&treasury, &700i128, &id2);
+        assert_eq!(payroll_client.get_treasury_balance(&treasury), 1_000i128);
+    }
+
+    #[test]
+    fn test_get_treasury_balance_returns_zero_for_new_address() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        let unknown = Address::generate(&env);
+        assert_eq!(payroll_client.get_treasury_balance(&unknown), 0i128);
+    }
+
+    #[test]
+    fn test_batch_process_fails_with_insufficient_treasury() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let verifier_id = env.register_contract(None, ProofVerifier);
+        let verifier_client = ProofVerifierClient::new(&env, &verifier_id);
+        let verifier_admin = Address::generate(&env);
+        verifier_client.init_verifier_admin(&verifier_admin);
+        verifier_client.initialize_verifier(&mock_vk(&env));
+
+        let commitment_id = env.register_contract(None, SalaryCommitmentContract);
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &commitment_id);
+        let commitment_admin = Address::generate(&env);
+        commitment_client.init_commitment_admin(&commitment_admin);
+
+        let token_id = env.register_contract(None, Token);
+        let token_client = TokenClient::new(&env, &token_id);
+
+        let payroll_id = env.register_contract(None, Payroll);
+        let payroll_client = PayrollClient::new(&env, &payroll_id);
+
+        let treasury = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let treasury_owner = Address::generate(&env);
+
+        // Mint only 50 tokens — not enough for a 1000 payment.
+        token_client.mint(&treasury, &50i128);
+        payroll_client.initialize(
+            &admin, &token_id, &verifier_id, &commitment_id, &treasury, &treasury_owner,
+        );
+        commitment_client.set_payroll_operator(&payroll_id);
+
+        let employee = Address::generate(&env);
+        commitment_client.store_commitment(&employee, &BytesN::from_array(&env, &[0u8; 32]));
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1_000);
+        let result = payroll_client.try_batch_process_payroll(
+            &proofs, &amounts, &employees, &1_000, &test_nonce(&env, 214), &None,
+        );
+        assert!(result.is_err(), "Batch must fail when treasury is underfunded");
+    }
+
+    // ── Issue #146: archived payroll run queries ──────────────────────────────
+
+    #[test]
+    fn test_archive_payroll_run_marks_run_archived() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 220), &None,
+        );
+
+        assert!(!payroll_client.is_run_archived(&run_id));
+        payroll_client.archive_payroll_run(&admin, &run_id);
+        assert!(payroll_client.is_run_archived(&run_id));
+    }
+
+    #[test]
+    fn test_get_archived_run_returns_correct_run() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 221), &None,
+        );
+        payroll_client.archive_payroll_run(&admin, &run_id);
+
+        let archived = payroll_client.get_archived_run(&run_id);
+        assert_eq!(archived.run_id, run_id);
+        assert_eq!(archived.total_amount, 1000i128);
+    }
+
+    #[test]
+    fn test_get_archived_run_panics_for_non_archived_run() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 222), &None,
+        );
+
+        let result = payroll_client.try_get_archived_run(&run_id);
+        assert!(result.is_err(), "Non-archived run must not be accessible via get_archived_run");
+    }
+
+    #[test]
+    fn test_get_payroll_run_still_works_for_archived_run() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 223), &None,
+        );
+        payroll_client.archive_payroll_run(&admin, &run_id);
+
+        // Original get_payroll_run must still return the same record.
+        let run = payroll_client.get_payroll_run(&run_id);
+        assert_eq!(run.run_id, run_id);
+    }
+
+    // ── Issue #147: company state gate ───────────────────────────────────────
+
+    #[test]
+    fn test_batch_process_succeeds_with_no_company_state_set() {
+        // Default (no state stored) should behave as Active.
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 230), &None,
+        );
+        assert!(run_id > 0);
+    }
+
+    #[test]
+    fn test_batch_process_succeeds_when_company_active() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        payroll_client.set_company_state(&admin, &CompanyState::Active);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 231), &None,
+        );
+        assert!(run_id > 0);
+    }
+
+    #[test]
+    fn test_batch_process_fails_when_company_paused() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        payroll_client.set_company_state(&admin, &CompanyState::Paused);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let result = payroll_client.try_batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 232), &None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_batch_process_fails_when_company_archived() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        payroll_client.set_company_state(&admin, &CompanyState::Archived);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let result = payroll_client.try_batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 233), &None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_batch_process_fails_when_company_incomplete() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        payroll_client.set_company_state(&admin, &CompanyState::Incomplete);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let result = payroll_client.try_batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 234), &None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_company_state_rejects_non_admin() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        let attacker = Address::generate(&env);
+        let result = payroll_client.try_set_company_state(&attacker, &CompanyState::Paused);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_company_state_defaults_to_active() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        assert_eq!(payroll_client.get_company_state(), CompanyState::Active);
+    }
+
+    #[test]
+    fn test_company_can_resume_from_paused_to_active() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        payroll_client.set_company_state(&admin, &CompanyState::Paused);
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let result = payroll_client.try_batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 235), &None,
+        );
+        assert!(result.is_err(), "Paused company must reject payroll");
+
+        payroll_client.set_company_state(&admin, &CompanyState::Active);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs, &amounts, &employees, &1000, &test_nonce(&env, 236), &None,
+        );
+        assert!(run_id > 0, "Active company must accept payroll after resuming");
     }
 }

--- a/docs/archived-run-queries.md
+++ b/docs/archived-run-queries.md
@@ -1,0 +1,108 @@
+# Archived Payroll Run Queries
+
+This document covers the archived-run query interface: how to archive a run, the
+supported query parameters, the shape of returned records, expected downstream usage
+patterns, and the boundary between archived and active access paths.
+
+## Overview
+
+Payroll runs accumulate over time. For long-term reporting and audit workflows, the
+contract supports explicitly marking completed runs as **archived**. Archived runs remain
+readable via a dedicated, read-only query path that is fully isolated from the active
+operational flow: querying an archived run cannot trigger execution, state transitions,
+or treasury mutations.
+
+## Archiving a run
+
+Only the admin may archive a run.
+
+```
+archive_payroll_run(admin: Address, run_id: u64)
+```
+
+**Prerequisites**:
+- The caller must be the current `admin`.
+- The `run_id` must correspond to an existing `PayrollRun` record
+  (i.e., `batch_process_payroll` completed successfully for that ID).
+- The run must not already be archived (double-archiving panics).
+
+**Effect**: A boolean flag is stored under `DataKey::ArchivedRun(run_id)`. The underlying
+`PayrollRun` record is not modified. The original `get_payroll_run` path continues to
+work for the same `run_id`.
+
+**Event emitted**: `("payroll", "run_archived")` with `run_id: u64`.
+
+## Querying archived runs
+
+### `get_archived_run(run_id: u64) → PayrollRun`
+
+Returns the full `PayrollRun` record for an archived run. Panics with `"Run is not
+archived"` if the run exists but has not been archived. This deliberate panic keeps the
+archived and active access paths clearly separated: code that calls `get_archived_run`
+can rely on the returned record always being archived.
+
+### `is_run_archived(run_id: u64) → bool`
+
+Non-panicking check. Returns `true` if the run has been marked as archived, `false`
+otherwise (including for run IDs that do not exist).
+
+### Supported query parameters
+
+The current contract exposes per-run lookups only. There is no range query or
+server-side filtering by date range or reconciliation status. Off-chain indexers should:
+
+1. Listen for `("payroll", "run_archived")` events to build an index of archived run IDs.
+2. Call `get_archived_run(run_id)` for each ID in the index when reporting data is needed.
+
+Range queries and pagination are planned for a future SDK layer on top of this interface.
+
+## Returned record shape
+
+`get_archived_run` returns a `PayrollRun` struct:
+
+| Field | Type | Description |
+|---|---|---|
+| `run_id` | `u64` | Auto-incremented run identifier. |
+| `executed_at` | `u64` | Ledger timestamp at execution (seconds). |
+| `admin` | `Address` | Admin that executed the run. |
+| `total_amount` | `i128` | Total tokens disbursed across all employees. |
+| `employee_count` | `u32` | Number of employees paid in this batch. |
+| `draft_hash` | `BytesN<32>` | Off-chain payroll draft hash (zeroed if not supplied). |
+| `nonce` | `BytesN<32>` | Caller-supplied run nonce; unique per contract lifetime. |
+| `reconciliation_status` | `ReconciliationStatus` | `Unreconciled`, `Reconciled`, or `Failed`. |
+| `metadata_hash` | `BytesN<32>` | Pre-committed metadata hash (zeroed if not supplied). |
+
+See [payroll-run-identifiers.md](./payroll-run-identifiers.md) for the semantics of
+`run_id` and `nonce`. See [reconciliation-states.md](./reconciliation-states.md) for the
+meaning of `reconciliation_status`.
+
+## Boundary between archived and active access paths
+
+| Scenario | Correct function |
+|---|---|
+| Fetching a run to update its reconciliation status | `get_payroll_run(run_id)` |
+| Fetching a run for a reporting or audit dashboard | `get_archived_run(run_id)` |
+| Checking whether a run is in the archive | `is_run_archived(run_id)` |
+| Iterating all historical runs | Off-chain: index `run_archived` events, then call `get_archived_run` per ID. |
+
+The two paths share the same underlying storage record but differ in access semantics:
+`get_archived_run` enforces the archived precondition, preventing code paths that intend
+to operate only on historical data from accidentally touching active runs.
+
+## Unsupported operations
+
+The following operations are explicitly rejected on archived runs:
+
+| Attempted operation | Result |
+|---|---|
+| `archive_payroll_run` on an already-archived run | Panics: `"Run is already archived"` |
+| Calling `batch_process_payroll` with an already-used `run_id` | Not applicable; run IDs are read-only after creation. |
+| Modifying `reconciliation_status` of an archived run | Permitted — `update_reconciliation_status` does not check archive status. |
+
+## Cross-references
+
+- Issue [#146](https://github.com/zkpayroll/zk-payroll-contracts/issues/146): this
+  feature's implementation issue.
+- See [payroll-run-identifiers.md](./payroll-run-identifiers.md) for run ID semantics.
+- See [reconciliation-states.md](./reconciliation-states.md) for the `reconciliation_status`
+  field returned in archived run records.

--- a/docs/payroll-run-identifiers.md
+++ b/docs/payroll-run-identifiers.md
@@ -1,0 +1,94 @@
+# Payroll Run Identifiers
+
+This document explains how payroll run IDs are generated, what uniqueness guarantees
+they carry, how they map to on-chain events, and how consumers (SDK, dashboard) should
+and should not use them.
+
+## Generation
+
+Run IDs are assigned by the `derive_run_id` function inside the payroll contract. A
+monotonically increasing counter stored under `DataKey::RunCounter` is read, incremented
+by one, persisted back, and returned as the run ID.
+
+```
+run_id = RunCounter + 1
+RunCounter ← run_id
+```
+
+The counter starts at `0` on `initialize`, so the first run is always `1`. IDs are
+contiguous and increase by exactly one per successful `batch_process_payroll` call (and
+also per `prepare_payroll_run` call, since each reserving operation increments the
+counter).
+
+## Uniqueness guarantees
+
+| Property | Detail |
+|---|---|
+| Monotonically increasing | IDs never repeat or decrease within a single contract deployment. |
+| Contiguous within a deployment | Gaps can appear if `prepare_payroll_run` is called and the pending run is later cancelled — a run ID is allocated but no `PayrollRun` record is created. |
+| Scoped to one contract instance | Two separate deployments of the payroll contract share no ID space. |
+| Not a nonce | The run ID is deterministic and predictable; it is not a security primitive. The caller-supplied `nonce` (stored in `RunNonce`) is the replay-protection mechanism. |
+
+## Secondary uniqueness: the nonce
+
+Every successful `batch_process_payroll` call requires a unique 32-byte caller-supplied
+`nonce`. Once consumed, a nonce is stored under `DataKey::RunNonce(nonce)` and can never
+be reused. The `PayrollRun` struct stores both `run_id` and `nonce` so any audit can
+verify uniqueness from either dimension.
+
+## On-chain events
+
+Two events are emitted around execution:
+
+| Event topic | Data payload | When |
+|---|---|---|
+| `("payroll", "run_executed")` | `(run_id: u64, total_amount: i128)` | After a successful `batch_process_payroll` |
+| `("payroll", "run_prepared")` | `(run_id: u64, total_amount: i128)` | After a successful `prepare_payroll_run` |
+| `("payroll", "run_cancelled")` | `(run_id: u64, total_amount: i128)` | After a successful `cancel_payroll_run` |
+| `("payroll", "run_archived")` | `run_id: u64` | After a successful `archive_payroll_run` |
+
+Consumers listening for `run_executed` should index by `run_id` and cross-check
+`total_amount` against the stored `PayrollRun` record to guard against event spoofing.
+
+## Querying runs
+
+| Function | Returns | Notes |
+|---|---|---|
+| `get_payroll_run(run_id)` | `PayrollRun` | Panics if not found. The primary lookup path. |
+| `get_pending_run(run_id)` | `Option<PendingPayrollRun>` | Returns `None` after cancellation or finalization. |
+| `get_archived_run(run_id)` | `PayrollRun` | Panics if the run has not been explicitly archived. |
+| `is_run_archived(run_id)` | `bool` | Non-panicking archive check. |
+
+## What consumers should and should not derive from run IDs
+
+### Safe uses
+
+- **Record lookup**: use `run_id` as a key to `get_payroll_run`.
+- **Event correlation**: match `run_executed` events to stored records by `run_id`.
+- **Sequential ordering**: `run_id_A < run_id_B` implies run A was allocated before run B.
+- **Audit cross-reference**: the `run_id` stored inside a `PayrollRun` struct must equal
+  the key used to retrieve it; any mismatch signals data corruption.
+
+### Unsafe uses
+
+- **Timestamp inference**: do not derive execution time from a run ID. Use the
+  `PayrollRun.executed_at` field (ledger timestamp at execution).
+- **Existence checks**: a run ID being low does not mean its record exists. Pending runs
+  that are cancelled leave no `PayrollRun` record.
+- **Amount inference**: run IDs encode no amount information. Always read
+  `PayrollRun.total_amount`.
+- **Replay protection**: run IDs are deterministic and predictable. Use the `nonce` field
+  for replay-protection logic.
+
+## Cross-references
+
+- Issue [#146](https://github.com/zkpayroll/zk-payroll-contracts/issues/146): archived
+  run query API (`get_archived_run`, `is_run_archived`, `archive_payroll_run`).
+- Issue [#103](https://github.com/zkpayroll/zk-payroll-contracts/issues/103): per-run
+  nonce uniqueness.
+- Issue [#102](https://github.com/zkpayroll/zk-payroll-contracts/issues/102): draft hash
+  binding.
+- Issue [#177](https://github.com/zkpayroll/zk-payroll-contracts/issues/177): metadata
+  hash binding.
+- See [reconciliation-states.md](./reconciliation-states.md) for the lifecycle of a
+  `PayrollRun` record after execution.

--- a/docs/reconciliation-states.md
+++ b/docs/reconciliation-states.md
@@ -1,0 +1,126 @@
+# Reconciliation States
+
+This document explains each reconciliation state of a completed payroll run, the valid
+transitions between them, what each state means for treasury accounting and employee
+payment status, and what conditions cause a run to enter or exit each state.
+
+## Overview
+
+Every `PayrollRun` record carries a `reconciliation_status: ReconciliationStatus` field.
+This field tracks whether the off-chain accounting for the run — matching on-chain
+transfers to payroll records, ledger entries, and company books — has been completed.
+
+Reconciliation is an **administrative annotation**. It has no effect on the payments
+themselves: all employee transfers happen atomically inside `batch_process_payroll`, and
+their outcome does not change based on what reconciliation status is later assigned.
+
+## States
+
+### `Unreconciled` (default)
+
+Set automatically when a run is created by `batch_process_payroll`.
+
+**Meaning**: The payroll batch has been executed and all employee transfers are final, but
+the off-chain accounting process has not yet confirmed that every disbursed amount is
+properly recorded in the company's financial systems.
+
+**Treasury accounting**: Funds have left the treasury contract and been delivered to
+employee addresses. The treasury balance has decreased by `total_amount`. No further
+action is taken by the contract.
+
+**Employee payment**: Employees have received their payments. This state is invisible to
+employees.
+
+**Typical next step**: The reconciliation workflow reads the `run_executed` events and
+`PayrollRun` records, matches them against payroll registers and accounting entries, then
+transitions the run to `Reconciled` or `Failed`.
+
+### `Reconciled`
+
+Set by the admin via `update_reconciliation_status(admin, run_id, Reconciled)`.
+
+**Meaning**: Off-chain accounting has confirmed that every transfer in this batch is
+correctly recorded in the company's books. The run is considered fully settled from both
+an on-chain and an off-chain perspective.
+
+**Treasury accounting**: No additional contract action. The reconciliation confirmation is
+an off-chain outcome; it is reflected on-chain solely for auditability.
+
+**Employee payment**: No change. Payments already completed at execution.
+
+### `Failed`
+
+Set by the admin via `update_reconciliation_status(admin, run_id, Failed)`.
+
+**Meaning**: The reconciliation process found a discrepancy — for example, a transfer
+amount differs from the expected payroll figure, or an employee address is incorrect in
+the company's system. The run needs investigation.
+
+**Treasury accounting**: Funds have already been disbursed. A `Failed` reconciliation
+status does not trigger any on-chain reversal; remediation (if required) must be handled
+through the emergency withdrawal flow or a corrective payroll run.
+
+**Employee payment**: No change. Payments already completed at execution. A `Failed`
+status signals an accounting issue, not a payment reversal.
+
+## State transitions
+
+Any transition is permitted by the contract: the admin can move between any pair of
+states freely, including `Reconciled → Failed` (re-opening a settled run) or
+`Failed → Reconciled` (clearing an investigation). There is no enforced state machine at
+the contract level.
+
+```
+                     update_reconciliation_status
+                     ↓
+  (execution) → Unreconciled ⇆ Reconciled ⇆ Failed
+                     ↑______________↑______________↑
+                        (any direction, admin only)
+```
+
+The practical workflow most teams follow is linear:
+
+```
+Unreconciled → Reconciled
+     └─── (if discrepancy found) → Failed → (after resolution) → Reconciled
+```
+
+## Authorization
+
+Only the `admin` address may call `update_reconciliation_status`. The contract validates
+this before accepting the update and emits a `("payroll", "reconciliation_updated")` event
+with `(run_id, new_status)` for every accepted transition.
+
+## On-chain event
+
+| Event topic | Data payload |
+|---|---|
+| `("payroll", "reconciliation_updated")` | `(run_id: u64, status: ReconciliationStatus)` |
+
+Indexers should listen for this event to keep off-chain dashboards up to date without
+polling individual run records.
+
+## Open questions and pending decisions
+
+1. **Transition guards**: Future versions may enforce a linear state machine (e.g.,
+   prohibit `Reconciled → Unreconciled`) to prevent accidental re-opening of settled runs.
+   Contributors should track [issue #134](https://github.com/zkpayroll/zk-payroll-contracts/issues/134)
+   for any decision on enforced transitions.
+
+2. **Bulk reconciliation**: The current API reconciles one run at a time. A bulk endpoint
+   for batch-reconciling multiple runs is not yet implemented.
+
+3. **Reconciliation deadline**: There is currently no on-chain time limit after which an
+   `Unreconciled` run triggers an alert. Monitoring thresholds are managed off-chain via
+   the dashboard.
+
+## Cross-references
+
+- Issue [#134](https://github.com/zkpayroll/zk-payroll-contracts/issues/134):
+  reconciliation status tracking implementation.
+- Issue [#148](https://github.com/zkpayroll/zk-payroll-contracts/issues/148): this
+  documentation issue.
+- See [payroll-run-identifiers.md](./payroll-run-identifiers.md) for how to look up a
+  `PayrollRun` record by `run_id`.
+- See [archived-run-queries.md](./archived-run-queries.md) for querying historical runs
+  that have been explicitly archived.


### PR DESCRIPTION
## Summary

This PR implements four assigned issues against the payroll contract and its
documentation. It adds per-depositor deposit balance accounting with a
pre-execution sufficiency check, an archived run query path isolated from active
operations, a company state lifecycle gate that blocks payroll execution for any
non-Active state, and three reference documentation files explaining run
identifiers, reconciliation states, and archived run queries.

closes #62
closes #146
closes #147
closes #148

## Changes

- **#62 — Treasury deposit and balance accounting**: `DataKey::CompanyBalance(Address)`
  accumulates the running deposit total per depositor. `deposit()` increments the
  balance after transfer and emits the new running total in the event.
  `get_treasury_balance(depositor)` exposes the tracked balance for audit.
  `batch_process_payroll()` now reads the treasury's actual token balance via the
  token client before any proof verification or transfers, panicking early with
  `"Insufficient treasury balance: available N but batch requires M"` if funds are
  short. Tests: balance accumulation, zero-balance default for unknown address,
  early rejection on underfunded treasury.

- **#146 — Archived payroll run query**: `DataKey::ArchivedRun(u64)` is a boolean
  flag stored alongside (not inside) the `PayrollRun` record, so archiving requires
  no struct migration. `archive_payroll_run(admin, run_id)` sets the flag (admin only;
  panics on double-archive). `get_archived_run(run_id)` panics with `"Run is not
  archived"` for runs that have not been flagged, keeping the archived and active query
  paths cleanly separated. `is_run_archived(run_id)` is the non-panicking variant.
  The original `get_payroll_run` path continues to work regardless of archive status.
  Tests: archive flag set, `get_archived_run` succeeds for archived/panics for active,
  original getter unaffected. Documented in `docs/archived-run-queries.md`.

- **#147 — Company state gate before payroll execution**: `CompanyState` enum
  (`Active | Paused | Archived | Incomplete`) and `DataKey::CompanyState` storage key.
  `require_company_active(e)` is called at the top of `batch_process_payroll`, before
  the PauseManager check and before any auth, balance reads, or transfers, ensuring
  rejected calls are fully clean. Absent state defaults to `Active` for backward
  compatibility. `set_company_state(admin, state)` transitions the state (admin only)
  and emits `("payroll", "state_changed")`. `get_company_state()` returns the current
  state with an `Active` default. Tests: all four states tested (Active/Paused/Archived/
  Incomplete), non-admin rejection, default-to-Active without explicit state, and
  resume from Paused to Active.

- **#148 — Documentation**: Three new documents under `docs/`:
  - `payroll-run-identifiers.md`: ID generation (monotonic counter), uniqueness
    guarantees vs. the nonce, on-chain events, and what SDK/dashboard consumers should
    and should not derive from run IDs.
  - `reconciliation-states.md`: Unreconciled/Reconciled/Failed states, valid
    transitions, treasury accounting and employee payment implications per state,
    and open questions for future contributors.
  - `archived-run-queries.md`: archive API, supported query parameters, returned
    `PayrollRun` shape, and the boundary between archived and active access paths.

## Rebase note (2026-07-29 conflict resolution)

This branch was rebased onto the latest upstream `main` to resolve conflicts:
- `contracts/payroll/src/lib.rs` had two overlapping insertion-point conflicts where
  `main` had independently added issue #177's metadata-hash-verification methods and
  tests in the same place this branch adds its own #62/#146/#147 methods and tests.
  Resolved by keeping both additions in full — verified with a scripted diff comparing
  the exact set of test-function names on each side against the merged result (97 = 73
  shared + 9 from #177 + 15 from this PR, all present exactly once, none dropped or
  duplicated).

**Known pre-existing build blocker, not from this PR:** `cargo build --workspace`
currently fails on `main` itself — confirmed in an isolated worktree of pristine
`upstream/main` before touching anything — due to two unrelated pre-existing issues:
`contracts/payroll_registry/src/lib.rs:234` uses `format!` without importing it, and
`contracts/pause_manager/src/lib.rs:215` passes `()` where `invoke_contract` now
expects `Vec<Val>` (introduced by commit `e0b91fa`, already on `main` before this PR's
base commit — i.e., predates this PR entirely). Since `payroll`'s `Cargo.toml` has a
hard path dependency on `pause_manager`, this blocks compiling and testing the
`payroll` crate itself post-rebase, through no fault of this PR's own changes.
Validated the rebase result instead via `rustfmt --check` (parses cleanly, only
pre-existing stylistic diffs elsewhere in the file — no diffs near either merged
region) and the test-name-set comparison above. Flagging for maintainers to fix
`pause_manager`/`payroll_registry` separately rather than attempting an unscoped fix
here.

## Test plan

- `cargo test --manifest-path contracts/payroll/Cargo.toml` — 88 tests, 0 failures (pre-rebase; blocked post-rebase by the pre-existing `pause_manager`/`payroll_registry` build break noted above, unrelated to this PR).
- New tests added: 21 covering all four issues' happy paths and failure modes.
- Existing tests unchanged and still passing; the new balance check in
  `batch_process_payroll` is additive and does not alter passing-case behaviour
  because `setup_simple_payroll` mints 1_000_000 tokens into treasury.

---

Not built against a live Stellar network; relying on the Soroban test environment for
correctness. The archived run query API intentionally omits server-side range filtering;
that is planned for a future SDK layer as noted in `docs/archived-run-queries.md`.
