### PR TITLE
fix(payroll_registry): validate employee wallet strkeys (#220)

### DIFF
--- a/contracts/payroll_registry/src/lib.rs
+++ b/contracts/payroll_registry/src/lib.rs
@@ -1,7 +1,11 @@
 #![no_std]
 
 use pause_manager::PauseManagerClient;
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, String, Symbol};
+
+const STELLAR_ACCOUNT_STRKEY_LEN: u32 = 56;
+const STELLAR_ACCOUNT_STRKEY_LEN_USIZE: usize = 56;
+const STELLAR_ACCOUNT_VERSION_BYTE: u8 = 6 << 3;
 
 // ---------------------------------------------------------------------------
 // Data types
@@ -87,6 +91,18 @@ pub trait PayrollRegistryTrait {
     /// The employee's initial status is set to `Active`.
     fn add_employee(env: Env, company_id: u64, employee: Address, commitment: BytesN<32>);
 
+    /// Validate a canonical Stellar account wallet string for employee onboarding.
+    fn validate_employee_wallet_format(env: Env, employee_wallet: String) -> bool;
+
+    /// Add an employee commitment from a Stellar account wallet string.
+    /// Requires authorisation from the company admin.
+    fn add_employee_by_wallet(
+        env: Env,
+        company_id: u64,
+        employee_wallet: String,
+        commitment: BytesN<32>,
+    );
+
     /// Permanently remove an employee record from storage.
     /// Requires authorisation from the company admin.
     fn remove_employee(env: Env, company_id: u64, employee: Address);
@@ -171,6 +187,120 @@ impl PayrollRegistry {
             .persistent()
             .set(&DataKey::PauseManager, &pause_manager);
     }
+
+    fn add_employee_record(env: Env, company_id: u64, employee: Address, commitment: BytesN<32>) {
+        Self::require_not_paused(&env);
+        let info: CompanyInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Company(company_id))
+            .expect("Company not found");
+
+        info.admin.require_auth();
+
+        let emp = employee.clone();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Employee(company_id, emp.clone()), &commitment);
+
+        // Default status for newly registered employees is Active (issue #90).
+        env.storage().persistent().set(
+            &DataKey::EmpStatus(company_id, emp),
+            &EmployeeStatus::Active,
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "EmployeeAdded"), company_id, employee),
+            (commitment,),
+        );
+        // topics : ("EmployeeAdded", company_id, employee)
+        // data   : (commitment,)
+    }
+
+    fn require_valid_employee_wallet_format(employee_wallet: &String) {
+        if !Self::employee_wallet_format_is_valid(employee_wallet) {
+            panic!("Invalid employee wallet address format");
+        }
+    }
+
+    fn employee_wallet_format_is_valid(employee_wallet: &String) -> bool {
+        if employee_wallet.len() != STELLAR_ACCOUNT_STRKEY_LEN {
+            return false;
+        }
+
+        let mut encoded = [0u8; STELLAR_ACCOUNT_STRKEY_LEN_USIZE];
+        employee_wallet.copy_into_slice(&mut encoded);
+
+        let mut decoded = [0u8; 35];
+        if !Self::decode_stellar_base32(&encoded, &mut decoded) {
+            return false;
+        }
+
+        if decoded[0] != STELLAR_ACCOUNT_VERSION_BYTE {
+            return false;
+        }
+
+        let expected_checksum = u16::from_le_bytes([decoded[33], decoded[34]]);
+        let actual_checksum = Self::crc16_xmodem(&decoded[..33]);
+        expected_checksum == actual_checksum
+    }
+
+    fn decode_stellar_base32(
+        encoded: &[u8; STELLAR_ACCOUNT_STRKEY_LEN_USIZE],
+        decoded: &mut [u8; 35],
+    ) -> bool {
+        let mut buffer: u16 = 0;
+        let mut bits_left: u8 = 0;
+        let mut out_index: usize = 0;
+
+        for ch in encoded {
+            let Some(value) = Self::decode_base32_char(*ch) else {
+                return false;
+            };
+            buffer = (buffer << 5) | u16::from(value);
+            bits_left += 5;
+
+            if bits_left >= 8 {
+                bits_left -= 8;
+                if out_index >= decoded.len() {
+                    return false;
+                }
+                decoded[out_index] = (buffer >> bits_left) as u8;
+                out_index += 1;
+
+                if bits_left > 0 {
+                    buffer &= (1u16 << bits_left) - 1;
+                } else {
+                    buffer = 0;
+                }
+            }
+        }
+
+        out_index == decoded.len() && bits_left == 0
+    }
+
+    fn decode_base32_char(ch: u8) -> Option<u8> {
+        match ch {
+            b'A'..=b'Z' => Some(ch - b'A'),
+            b'2'..=b'7' => Some(ch - b'2' + 26),
+            _ => None,
+        }
+    }
+
+    fn crc16_xmodem(bytes: &[u8]) -> u16 {
+        let mut crc: u16 = 0;
+        for byte in bytes {
+            crc ^= u16::from(*byte) << 8;
+            for _ in 0..8 {
+                if (crc & 0x8000) != 0 {
+                    crc = (crc << 1) ^ 0x1021;
+                } else {
+                    crc <<= 1;
+                }
+            }
+        }
+        crc
+    }
 }
 
 #[contractimpl]
@@ -218,39 +348,22 @@ impl PayrollRegistryTrait for PayrollRegistry {
     }
 
     fn add_employee(env: Env, company_id: u64, employee: Address, commitment: BytesN<32>) {
-        Self::require_not_paused(&env);
-        let info: CompanyInfo = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Company(company_id))
-            .expect("Company not found");
+        Self::add_employee_record(env, company_id, employee, commitment);
+    }
 
-        info.admin.require_auth();
+    fn validate_employee_wallet_format(_env: Env, employee_wallet: String) -> bool {
+        Self::employee_wallet_format_is_valid(&employee_wallet)
+    }
 
-        // Issue #220: Validate employee wallet format before accepting into state
-        // Ensure employee address is valid (Soroban validates this implicitly,
-        // but we explicitly check for zero-length to catch invalid formats early)
-        let emp = employee.clone();
-        let emp_str = format!("{:?}", emp);
-        if emp_str.is_empty() {
-            panic!("Invalid employee wallet address format");
-        }
-        env.storage()
-            .persistent()
-            .set(&DataKey::Employee(company_id, emp.clone()), &commitment);
-
-        // Default status for newly registered employees is Active (issue #90).
-        env.storage().persistent().set(
-            &DataKey::EmpStatus(company_id, emp),
-            &EmployeeStatus::Active,
-        );
-
-        env.events().publish(
-            (Symbol::new(&env, "EmployeeAdded"), company_id, employee),
-            (commitment,),
-        );
-        // topics : ("EmployeeAdded", company_id, employee)
-        // data   : (commitment,)
+    fn add_employee_by_wallet(
+        env: Env,
+        company_id: u64,
+        employee_wallet: String,
+        commitment: BytesN<32>,
+    ) {
+        Self::require_valid_employee_wallet_format(&employee_wallet);
+        let employee = Address::from_string(&employee_wallet);
+        Self::add_employee_record(env, company_id, employee, commitment);
     }
 
     fn remove_employee(env: Env, company_id: u64, employee: Address) {

--- a/contracts/payroll_registry/src/tests.rs
+++ b/contracts/payroll_registry/src/tests.rs
@@ -1,6 +1,11 @@
 use super::*;
 use soroban_sdk::testutils::{Address as _, Events};
-use soroban_sdk::{Env, IntoVal, Symbol, TryIntoVal};
+use soroban_sdk::{Env, IntoVal, String, Symbol, TryIntoVal};
+
+const VALID_EMPLOYEE_WALLET: &str =
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const BAD_CHECKSUM_EMPLOYEE_WALLET: &str =
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHA";
 
 fn setup() -> (Env, Address) {
     let env = Env::default();
@@ -80,6 +85,66 @@ fn test_add_employee_stores_commitment() {
             .expect("employee commitment should be stored")
     });
     assert_eq!(stored, commitment);
+}
+
+#[test]
+fn test_validate_employee_wallet_format_accepts_valid_account_strkey() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let wallet = String::from_str(&env, VALID_EMPLOYEE_WALLET);
+
+    assert!(client.validate_employee_wallet_format(&wallet));
+}
+
+#[test]
+fn test_validate_employee_wallet_format_rejects_invalid_wallets() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let short_wallet = String::from_str(&env, "GSHORT");
+    let bad_checksum_wallet = String::from_str(&env, BAD_CHECKSUM_EMPLOYEE_WALLET);
+    let contract_strkey = Address::generate(&env).to_string();
+
+    assert!(!client.validate_employee_wallet_format(&short_wallet));
+    assert!(!client.validate_employee_wallet_format(&bad_checksum_wallet));
+    assert!(!client.validate_employee_wallet_format(&contract_strkey));
+}
+
+#[test]
+fn test_add_employee_by_wallet_stores_commitment() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let wallet = String::from_str(&env, VALID_EMPLOYEE_WALLET);
+    let employee = Address::from_string(&wallet);
+    let commitment = BytesN::from_array(&env, &[1u8; 32]);
+
+    let company_id = client.register_company(&admin, &treasury);
+    client.add_employee_by_wallet(&company_id, &wallet, &commitment);
+
+    assert_eq!(client.get_commitment(&company_id, &employee), commitment);
+    assert_eq!(
+        client.get_employee_status(&company_id, &employee),
+        EmployeeStatus::Active,
+    );
+}
+
+#[test]
+fn test_add_employee_by_wallet_rejects_invalid_wallet_before_storage() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let bad_wallet = String::from_str(&env, BAD_CHECKSUM_EMPLOYEE_WALLET);
+    let commitment = BytesN::from_array(&env, &[1u8; 32]);
+
+    let company_id = client.register_company(&admin, &treasury);
+    let before = env.events().all().len();
+    let result = client.try_add_employee_by_wallet(&company_id, &bad_wallet, &commitment);
+    let after = env.events().all().len();
+
+    assert!(result.is_err());
+    assert_eq!(after, before);
 }
 
 #[test]


### PR DESCRIPTION
Closes #220

## Changes
- Added explicit employee wallet validation for canonical Stellar account strkeys before converting wallet strings into contract state addresses.
- Added `validate_employee_wallet_format` for preflight checks and `add_employee_by_wallet` for onboarding from wallet strings.
- Reused the existing employee storage path so status defaults, auth checks, and events remain consistent.
- Added tests for valid account wallets, short strings, bad checksums, contract-address rejection, and invalid wallet rejection before state/event writes.

## Testing
- `git diff --check` passed.
- `cargo test -p payroll_registry --offline` was attempted, but Windows Application Control blocked Cargo build-script execution for `num-traits` with `os error 4551` before the crate tests could run.
- `cargo fmt -p payroll_registry` was also blocked by the same Application Control policy.