### PR TITLE
Add formal payroll state machine and conformance tests

### DIFF
--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -34,6 +34,28 @@ pub enum ReconciliationStatus {
     Failed,
 }
 
+/// Canonical payroll run state shared by contracts, SDKs, and dashboards (#159).
+///
+/// This enum is the source of truth for user-visible payroll run lifecycle
+/// labels. Off-chain clients should mirror these exact names and transition
+/// rules from `docs/payroll-state-machine.md` and the JSON fixture under
+/// `fixtures/state-machine/`.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum PayrollRunState {
+    Draft = 0,
+    Validating = 1,
+    ProofPending = 2,
+    ReadyToSubmit = 3,
+    Submitted = 4,
+    Confirming = 5,
+    Completed = 6,
+    Failed = 7,
+    Cancelled = 8,
+    ReconciliationRequired = 9,
+}
+
 /// A pending payroll run that has been prepared but not yet finalized.
 /// Stores the metadata needed to execute the run without exposing salary amounts.
 ///
@@ -282,6 +304,8 @@ pub enum DataKey {
     ArchivedRun(u64),
     /// Company lifecycle state gate for payroll execution (#147).
     CompanyState,
+    /// Canonical payroll run state for SDK/dashboard conformance (#159).
+    PayrollState(u64),
     // Future upgrade example (issue #196):
     // PayrollRunV2(u64),  // Would be added here when schema evolution is needed
 }
@@ -435,6 +459,151 @@ impl Payroll {
         e.storage().persistent().set(&DataKey::RunCounter, &run_id);
 
         run_id
+    }
+
+    fn is_allowed_payroll_state_transition_internal(
+        from: PayrollRunState,
+        to: PayrollRunState,
+    ) -> bool {
+        match from {
+            PayrollRunState::Draft => matches!(
+                to,
+                PayrollRunState::Validating | PayrollRunState::Cancelled
+            ),
+            PayrollRunState::Validating => matches!(
+                to,
+                PayrollRunState::ProofPending
+                    | PayrollRunState::Failed
+                    | PayrollRunState::Cancelled
+            ),
+            PayrollRunState::ProofPending => matches!(
+                to,
+                PayrollRunState::ReadyToSubmit
+                    | PayrollRunState::Failed
+                    | PayrollRunState::Cancelled
+            ),
+            PayrollRunState::ReadyToSubmit => matches!(
+                to,
+                PayrollRunState::Submitted | PayrollRunState::Failed | PayrollRunState::Cancelled
+            ),
+            PayrollRunState::Submitted => matches!(
+                to,
+                PayrollRunState::Confirming | PayrollRunState::Failed | PayrollRunState::Cancelled
+            ),
+            PayrollRunState::Confirming => matches!(
+                to,
+                PayrollRunState::Completed
+                    | PayrollRunState::Failed
+                    | PayrollRunState::ReconciliationRequired
+            ),
+            PayrollRunState::Failed => matches!(
+                to,
+                PayrollRunState::Validating
+                    | PayrollRunState::ProofPending
+                    | PayrollRunState::Cancelled
+            ),
+            PayrollRunState::ReconciliationRequired => {
+                matches!(to, PayrollRunState::Completed | PayrollRunState::Failed)
+            }
+            PayrollRunState::Completed | PayrollRunState::Cancelled => false,
+        }
+    }
+
+    fn is_terminal_payroll_state_internal(state: PayrollRunState) -> bool {
+        matches!(state, PayrollRunState::Completed | PayrollRunState::Cancelled)
+    }
+
+    fn is_retryable_payroll_state_internal(state: PayrollRunState) -> bool {
+        matches!(state, PayrollRunState::Failed)
+    }
+
+    fn record_payroll_run_state(e: &Env, run_id: u64, state: PayrollRunState) {
+        e.storage()
+            .persistent()
+            .set(&DataKey::PayrollState(run_id), &state);
+        e.events().publish(
+            (symbol_short!("payroll"), Symbol::new(e, "run_state")),
+            (run_id, state),
+        );
+    }
+
+    fn get_payroll_run_state_internal(e: &Env, run_id: u64) -> PayrollRunState {
+        if let Some(state) = e
+            .storage()
+            .persistent()
+            .get::<_, PayrollRunState>(&DataKey::PayrollState(run_id))
+        {
+            return state;
+        }
+
+        if let Some(run) = e
+            .storage()
+            .persistent()
+            .get::<_, PayrollRun>(&DataKey::PayrollRun(run_id))
+        {
+            return match run.reconciliation_status {
+                ReconciliationStatus::Reconciled => PayrollRunState::Completed,
+                ReconciliationStatus::Unreconciled | ReconciliationStatus::Failed => {
+                    PayrollRunState::ReconciliationRequired
+                }
+            };
+        }
+
+        if e.storage().persistent().has(&DataKey::PendingRun(run_id)) {
+            return PayrollRunState::Submitted;
+        }
+
+        panic!("Payroll run state not found");
+    }
+
+    /// Return whether a transition is allowed by the canonical state machine.
+    pub fn is_payroll_state_transition_allowed(
+        _e: Env,
+        from: PayrollRunState,
+        to: PayrollRunState,
+    ) -> bool {
+        Self::is_allowed_payroll_state_transition_internal(from, to)
+    }
+
+    /// Return whether a payroll run state is terminal and immutable.
+    pub fn is_payroll_state_terminal(_e: Env, state: PayrollRunState) -> bool {
+        Self::is_terminal_payroll_state_internal(state)
+    }
+
+    /// Return whether a state should expose a retry action to clients.
+    pub fn is_payroll_state_retryable(_e: Env, state: PayrollRunState) -> bool {
+        Self::is_retryable_payroll_state_internal(state)
+    }
+
+    /// Return the canonical state for a payroll run ID.
+    pub fn get_payroll_run_state(e: Env, run_id: u64) -> PayrollRunState {
+        Self::get_payroll_run_state_internal(&e, run_id)
+    }
+
+    /// Admin-only state transition hook for conformance tests and operations.
+    pub fn transition_payroll_run_state(
+        e: Env,
+        admin: Address,
+        run_id: u64,
+        next_state: PayrollRunState,
+    ) {
+        Self::require_not_paused(&e);
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+
+        let current = Self::get_payroll_run_state_internal(&e, run_id);
+        if !Self::is_allowed_payroll_state_transition_internal(current, next_state) {
+            panic!("Invalid payroll state transition");
+        }
+
+        Self::record_payroll_run_state(&e, run_id, next_state);
     }
 
     pub fn get_payroll_run(e: Env, run_id: u64) -> PayrollRun {
@@ -758,6 +927,7 @@ impl Payroll {
         e.storage()
             .persistent()
             .set(&DataKey::PendingRun(run_id), &pending_run);
+        Self::record_payroll_run_state(&e, run_id, PayrollRunState::Submitted);
 
         e.events().publish(
             (symbol_short!("payroll"), Symbol::new(&e, "run_prepared")),
@@ -811,6 +981,7 @@ impl Payroll {
 
         // Remove the pending run from storage
         e.storage().persistent().remove(&pending_key);
+        Self::record_payroll_run_state(&e, run_id, PayrollRunState::Cancelled);
 
         // Emit cancellation event
         e.events().publish(
@@ -979,6 +1150,7 @@ impl Payroll {
         e.storage()
             .persistent()
             .set(&DataKey::PayrollRun(run_id), &run);
+        Self::record_payroll_run_state(&e, run_id, PayrollRunState::ReconciliationRequired);
 
         e.events().publish(
             (symbol_short!("payroll"), Symbol::new(&e, "run_executed")),
@@ -1103,6 +1275,19 @@ impl Payroll {
 
         run.reconciliation_status = status.clone();
         e.storage().persistent().set(&run_key, &run);
+
+        let current_state = Self::get_payroll_run_state_internal(&e, run_id);
+        let next_state = match status {
+            ReconciliationStatus::Reconciled => PayrollRunState::Completed,
+            ReconciliationStatus::Unreconciled => PayrollRunState::ReconciliationRequired,
+            ReconciliationStatus::Failed => PayrollRunState::Failed,
+        };
+        if current_state != next_state
+            && !Self::is_allowed_payroll_state_transition_internal(current_state, next_state)
+        {
+            panic!("Invalid payroll state transition");
+        }
+        Self::record_payroll_run_state(&e, run_id, next_state);
 
         e.events().publish(
             (
@@ -2401,10 +2586,45 @@ mod tests {
         let run = payroll_client.get_payroll_run(&run_id);
         assert_eq!(run.reconciliation_status, ReconciliationStatus::Reconciled);
 
-        // Update to Failed
-        payroll_client.update_reconciliation_status(&admin, &run_id, &ReconciliationStatus::Failed);
-        let run = payroll_client.get_payroll_run(&run_id);
-        assert_eq!(run.reconciliation_status, ReconciliationStatus::Failed);
+        assert_eq!(
+            payroll_client.get_payroll_run_state(&run_id),
+            PayrollRunState::Completed
+        );
+
+        let result = payroll_client.try_update_reconciliation_status(
+            &admin,
+            &run_id,
+            &ReconciliationStatus::Failed,
+        );
+        assert!(result.is_err(), "Completed runs must not be reopened");
+    }
+
+    #[test]
+    fn test_failed_reconciliation_writes_retryable_payroll_state() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&env, 33),
+            &None,
+        );
+
+        payroll_client.update_reconciliation_status(
+            &admin,
+            &run_id,
+            &ReconciliationStatus::Failed,
+        );
+        assert_eq!(
+            payroll_client.get_payroll_run_state(&run_id),
+            PayrollRunState::Failed
+        );
+        assert!(payroll_client.is_payroll_state_retryable(&PayrollRunState::Failed));
     }
 
     #[test]
@@ -2447,6 +2667,159 @@ mod tests {
     }
 
     // ── Issue #75: payroll cancellation ──────────────────────────────────────
+
+    // ── Issue #159: canonical payroll state machine ──────────────────────────
+
+    #[test]
+    fn test_payroll_state_machine_allows_canonical_forward_transitions() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        assert!(payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::Draft,
+            &PayrollRunState::Validating,
+        ));
+        assert!(payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::Validating,
+            &PayrollRunState::ProofPending,
+        ));
+        assert!(payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::ProofPending,
+            &PayrollRunState::ReadyToSubmit,
+        ));
+        assert!(payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::ReadyToSubmit,
+            &PayrollRunState::Submitted,
+        ));
+        assert!(payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::Submitted,
+            &PayrollRunState::Confirming,
+        ));
+        assert!(payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::Confirming,
+            &PayrollRunState::ReconciliationRequired,
+        ));
+        assert!(payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::ReconciliationRequired,
+            &PayrollRunState::Completed,
+        ));
+    }
+
+    #[test]
+    fn test_payroll_state_machine_rejects_forbidden_transitions() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        assert!(!payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::Draft,
+            &PayrollRunState::Completed,
+        ));
+        assert!(!payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::Submitted,
+            &PayrollRunState::Draft,
+        ));
+        assert!(!payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::Completed,
+            &PayrollRunState::Failed,
+        ));
+        assert!(!payroll_client.is_payroll_state_transition_allowed(
+            &PayrollRunState::Cancelled,
+            &PayrollRunState::Submitted,
+        ));
+    }
+
+    #[test]
+    fn test_payroll_state_machine_terminal_and_retryable_metadata() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, _employee) =
+            setup_simple_payroll(&env);
+
+        assert!(payroll_client.is_payroll_state_terminal(&PayrollRunState::Completed));
+        assert!(payroll_client.is_payroll_state_terminal(&PayrollRunState::Cancelled));
+        assert!(!payroll_client.is_payroll_state_terminal(&PayrollRunState::Failed));
+        assert!(payroll_client.is_payroll_state_retryable(&PayrollRunState::Failed));
+        assert!(
+            !payroll_client.is_payroll_state_retryable(&PayrollRunState::ReconciliationRequired)
+        );
+    }
+
+    #[test]
+    fn test_prepare_and_cancel_write_canonical_payroll_states() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&env, 150),
+            &None,
+        );
+        assert_eq!(
+            payroll_client.get_payroll_run_state(&run_id),
+            PayrollRunState::Submitted
+        );
+
+        payroll_client.cancel_payroll_run(&admin, &run_id);
+        assert_eq!(
+            payroll_client.get_payroll_run_state(&run_id),
+            PayrollRunState::Cancelled
+        );
+    }
+
+    #[test]
+    fn test_terminal_payroll_state_cannot_be_mutated() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&env, 151),
+            &None,
+        );
+        payroll_client.cancel_payroll_run(&admin, &run_id);
+
+        let result = payroll_client.try_transition_payroll_run_state(
+            &admin,
+            &run_id,
+            &PayrollRunState::Submitted,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_non_admin_cannot_transition_payroll_state() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&env, 152),
+            &None,
+        );
+        let attacker = Address::generate(&env);
+        let result = payroll_client.try_transition_payroll_run_state(
+            &attacker,
+            &run_id,
+            &PayrollRunState::Confirming,
+        );
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_prepare_payroll_run_creates_pending_run() {

--- a/docs/payroll-state-machine.md
+++ b/docs/payroll-state-machine.md
@@ -1,0 +1,90 @@
+# Payroll Run State Machine
+
+Issue #159 defines the canonical payroll run lifecycle that contracts, SDKs, and
+dashboards must mirror. The contract source of truth is
+`PayrollRunState` in `contracts/payroll/src/lib.rs`; the machine-readable mirror
+is `fixtures/state-machine/payroll-run-state-machine.json`.
+
+## Canonical States
+
+| State | Contract variant | Terminal | Retryable | Semantics |
+| --- | --- | --- | --- | --- |
+| `draft` | `Draft` | No | No | Payroll inputs are still being assembled off-chain. |
+| `validating` | `Validating` | No | No | Payroll inputs are being checked before proof work begins. |
+| `proof_pending` | `ProofPending` | No | No | Required ZK proof or verification artifacts are being produced. |
+| `ready_to_submit` | `ReadyToSubmit` | No | No | All validation artifacts are present and the run is ready for submission. |
+| `submitted` | `Submitted` | No | No | The run has been prepared on-chain and is waiting to be executed or cancelled. |
+| `confirming` | `Confirming` | No | No | Execution has been submitted and clients should wait for final confirmation. |
+| `completed` | `Completed` | Yes | No | Payroll completed and reconciliation is final. |
+| `failed` | `Failed` | No | Yes | The run failed before a terminal outcome and may be retried or cancelled. |
+| `cancelled` | `Cancelled` | Yes | No | The run was intentionally stopped and cannot be reopened. |
+| `reconciliation_required` | `ReconciliationRequired` | No | No | Payments executed, but reconciliation still needs review or finalization. |
+
+`completed` and `cancelled` are immutable terminal states. `failed` is the only
+retryable state. `reconciliation_required` is reviewable, but clients should not
+show it as a retry action by default because the next step is reconciliation or
+operator review.
+
+## Allowed Transitions
+
+| From | To | Initiator | User-visible meaning |
+| --- | --- | --- | --- |
+| `draft` | `validating` | Payroll operator or automation | Start validating a draft run. |
+| `draft` | `cancelled` | Payroll operator | Stop a run before validation. |
+| `validating` | `proof_pending` | Validation service | Inputs passed validation and proof work can start. |
+| `validating` | `failed` | Validation service | Validation failed and the run can be retried. |
+| `validating` | `cancelled` | Payroll operator | Stop a run during validation. |
+| `proof_pending` | `ready_to_submit` | Proof service | Required proof artifacts are ready. |
+| `proof_pending` | `failed` | Proof service | Proof generation or verification failed. |
+| `proof_pending` | `cancelled` | Payroll operator | Stop a run while proofs are pending. |
+| `ready_to_submit` | `submitted` | Payroll operator or submitter | Submit the prepared payroll run on-chain. |
+| `ready_to_submit` | `failed` | Submitter or automation | Submission preparation failed. |
+| `ready_to_submit` | `cancelled` | Payroll operator | Stop a run before on-chain submission. |
+| `submitted` | `confirming` | Contract, submitter, or indexer | Execution has been sent and confirmation is pending. |
+| `submitted` | `failed` | Contract, submitter, or indexer | Submission failed before confirmation. |
+| `submitted` | `cancelled` | Admin | Cancel a prepared run before execution. |
+| `confirming` | `completed` | Contract or reconciliation operator | Execution and reconciliation are final. |
+| `confirming` | `failed` | Contract or reconciliation operator | Confirmation failed before a terminal success. |
+| `confirming` | `reconciliation_required` | Contract or reconciliation operator | Execution happened, but reconciliation must be completed. |
+| `failed` | `validating` | Payroll operator or automation | Retry from validation. |
+| `failed` | `proof_pending` | Payroll operator or automation | Retry from proof generation when inputs remain valid. |
+| `failed` | `cancelled` | Payroll operator | Stop a failed run instead of retrying. |
+| `reconciliation_required` | `completed` | Reconciliation operator | Reconciliation succeeded and the run is final. |
+| `reconciliation_required` | `failed` | Reconciliation operator | Reconciliation failed and the run requires retry handling. |
+
+All other transitions are forbidden. In particular, clients and integrations
+must reject direct jumps such as `draft -> completed`, reverse transitions such
+as `submitted -> draft`, and any transition out of `completed` or `cancelled`.
+
+## Contract Entry Points
+
+The payroll contract records canonical state for the on-chain lifecycle:
+
+| Entry point | State effect |
+| --- | --- |
+| `prepare_payroll_run` | Stores `submitted` for the new pending run. |
+| `cancel_payroll_run` | Stores `cancelled` and removes the pending run. |
+| `batch_process_payroll` | Stores `reconciliation_required` after execution. |
+| `update_reconciliation_status(Reconciled)` | Stores `completed`. |
+| `update_reconciliation_status(Unreconciled)` | Keeps or stores `reconciliation_required`. |
+| `update_reconciliation_status(Failed)` | Stores retryable `failed`. |
+| `transition_payroll_run_state` | Admin-only conformance hook that rejects forbidden transitions. |
+| `get_payroll_run_state` | Reads the canonical state for a run ID. |
+
+The contract exposes `is_payroll_state_transition_allowed`,
+`is_payroll_state_terminal`, and `is_payroll_state_retryable` so tests and
+off-chain mirrors can assert the same semantics without duplicating rules.
+
+## Future Additions
+
+When adding or renaming a state, update all of the following in the same pull
+request:
+
+1. `PayrollRunState` and the internal transition table in `contracts/payroll/src/lib.rs`.
+2. Positive and negative contract tests for the new transition behavior.
+3. `fixtures/state-machine/payroll-run-state-machine.json` for SDK/dashboard conformance.
+4. This document, including initiators, terminal/retryable metadata, and user-visible meaning.
+
+Never add a transition out of a terminal state without first changing the
+terminal-state definition and adding tests that prove existing terminal behavior
+is intentionally replaced.

--- a/fixtures/state-machine/payroll-run-state-machine.json
+++ b/fixtures/state-machine/payroll-run-state-machine.json
@@ -1,0 +1,294 @@
+{
+  "version": 1,
+  "issue": 159,
+  "source": "contracts/payroll/src/lib.rs::PayrollRunState",
+  "documentation": "docs/payroll-state-machine.md",
+  "states": [
+    {
+      "name": "draft",
+      "contract_variant": "Draft",
+      "ordinal": 0,
+      "terminal": false,
+      "retryable": false,
+      "user_visible": true,
+      "description": "Payroll inputs are still being assembled off-chain."
+    },
+    {
+      "name": "validating",
+      "contract_variant": "Validating",
+      "ordinal": 1,
+      "terminal": false,
+      "retryable": false,
+      "user_visible": true,
+      "description": "Payroll inputs are being checked before proof work begins."
+    },
+    {
+      "name": "proof_pending",
+      "contract_variant": "ProofPending",
+      "ordinal": 2,
+      "terminal": false,
+      "retryable": false,
+      "user_visible": true,
+      "description": "Required ZK proof or verification artifacts are being produced."
+    },
+    {
+      "name": "ready_to_submit",
+      "contract_variant": "ReadyToSubmit",
+      "ordinal": 3,
+      "terminal": false,
+      "retryable": false,
+      "user_visible": true,
+      "description": "All validation artifacts are present and the run is ready for submission."
+    },
+    {
+      "name": "submitted",
+      "contract_variant": "Submitted",
+      "ordinal": 4,
+      "terminal": false,
+      "retryable": false,
+      "user_visible": true,
+      "description": "The run has been prepared on-chain and is waiting to be executed or cancelled."
+    },
+    {
+      "name": "confirming",
+      "contract_variant": "Confirming",
+      "ordinal": 5,
+      "terminal": false,
+      "retryable": false,
+      "user_visible": true,
+      "description": "Execution has been submitted and clients should wait for final confirmation."
+    },
+    {
+      "name": "completed",
+      "contract_variant": "Completed",
+      "ordinal": 6,
+      "terminal": true,
+      "retryable": false,
+      "user_visible": true,
+      "description": "Payroll completed and reconciliation is final."
+    },
+    {
+      "name": "failed",
+      "contract_variant": "Failed",
+      "ordinal": 7,
+      "terminal": false,
+      "retryable": true,
+      "user_visible": true,
+      "description": "The run failed before a terminal outcome and may be retried or cancelled."
+    },
+    {
+      "name": "cancelled",
+      "contract_variant": "Cancelled",
+      "ordinal": 8,
+      "terminal": true,
+      "retryable": false,
+      "user_visible": true,
+      "description": "The run was intentionally stopped and cannot be reopened."
+    },
+    {
+      "name": "reconciliation_required",
+      "contract_variant": "ReconciliationRequired",
+      "ordinal": 9,
+      "terminal": false,
+      "retryable": false,
+      "user_visible": true,
+      "description": "Payments executed, but reconciliation still needs review or finalization."
+    }
+  ],
+  "terminal_states": ["completed", "cancelled"],
+  "retryable_states": ["failed"],
+  "transitions": [
+    {
+      "from": "draft",
+      "to": "validating",
+      "initiator": "payroll_operator_or_automation",
+      "user_visible": true,
+      "reason": "Start validating a draft run."
+    },
+    {
+      "from": "draft",
+      "to": "cancelled",
+      "initiator": "payroll_operator",
+      "user_visible": true,
+      "reason": "Stop a run before validation."
+    },
+    {
+      "from": "validating",
+      "to": "proof_pending",
+      "initiator": "validation_service",
+      "user_visible": true,
+      "reason": "Inputs passed validation and proof work can start."
+    },
+    {
+      "from": "validating",
+      "to": "failed",
+      "initiator": "validation_service",
+      "user_visible": true,
+      "reason": "Validation failed and the run can be retried."
+    },
+    {
+      "from": "validating",
+      "to": "cancelled",
+      "initiator": "payroll_operator",
+      "user_visible": true,
+      "reason": "Stop a run during validation."
+    },
+    {
+      "from": "proof_pending",
+      "to": "ready_to_submit",
+      "initiator": "proof_service",
+      "user_visible": true,
+      "reason": "Required proof artifacts are ready."
+    },
+    {
+      "from": "proof_pending",
+      "to": "failed",
+      "initiator": "proof_service",
+      "user_visible": true,
+      "reason": "Proof generation or verification failed."
+    },
+    {
+      "from": "proof_pending",
+      "to": "cancelled",
+      "initiator": "payroll_operator",
+      "user_visible": true,
+      "reason": "Stop a run while proofs are pending."
+    },
+    {
+      "from": "ready_to_submit",
+      "to": "submitted",
+      "initiator": "payroll_operator_or_submitter",
+      "user_visible": true,
+      "reason": "Submit the prepared payroll run on-chain."
+    },
+    {
+      "from": "ready_to_submit",
+      "to": "failed",
+      "initiator": "submitter_or_automation",
+      "user_visible": true,
+      "reason": "Submission preparation failed."
+    },
+    {
+      "from": "ready_to_submit",
+      "to": "cancelled",
+      "initiator": "payroll_operator",
+      "user_visible": true,
+      "reason": "Stop a run before on-chain submission."
+    },
+    {
+      "from": "submitted",
+      "to": "confirming",
+      "initiator": "contract_submitter_or_indexer",
+      "user_visible": true,
+      "reason": "Execution has been sent and confirmation is pending."
+    },
+    {
+      "from": "submitted",
+      "to": "failed",
+      "initiator": "contract_submitter_or_indexer",
+      "user_visible": true,
+      "reason": "Submission failed before confirmation."
+    },
+    {
+      "from": "submitted",
+      "to": "cancelled",
+      "initiator": "admin",
+      "user_visible": true,
+      "reason": "Cancel a prepared run before execution."
+    },
+    {
+      "from": "confirming",
+      "to": "completed",
+      "initiator": "contract_or_reconciliation_operator",
+      "user_visible": true,
+      "reason": "Execution and reconciliation are final."
+    },
+    {
+      "from": "confirming",
+      "to": "failed",
+      "initiator": "contract_or_reconciliation_operator",
+      "user_visible": true,
+      "reason": "Confirmation failed before a terminal success."
+    },
+    {
+      "from": "confirming",
+      "to": "reconciliation_required",
+      "initiator": "contract_or_reconciliation_operator",
+      "user_visible": true,
+      "reason": "Execution happened, but reconciliation must be completed."
+    },
+    {
+      "from": "failed",
+      "to": "validating",
+      "initiator": "payroll_operator_or_automation",
+      "user_visible": true,
+      "reason": "Retry from validation."
+    },
+    {
+      "from": "failed",
+      "to": "proof_pending",
+      "initiator": "payroll_operator_or_automation",
+      "user_visible": true,
+      "reason": "Retry from proof generation when inputs remain valid."
+    },
+    {
+      "from": "failed",
+      "to": "cancelled",
+      "initiator": "payroll_operator",
+      "user_visible": true,
+      "reason": "Stop a failed run instead of retrying."
+    },
+    {
+      "from": "reconciliation_required",
+      "to": "completed",
+      "initiator": "reconciliation_operator",
+      "user_visible": true,
+      "reason": "Reconciliation succeeded and the run is final."
+    },
+    {
+      "from": "reconciliation_required",
+      "to": "failed",
+      "initiator": "reconciliation_operator",
+      "user_visible": true,
+      "reason": "Reconciliation failed and the run requires retry handling."
+    }
+  ],
+  "forbidden_examples": [
+    {
+      "from": "draft",
+      "to": "completed",
+      "reason": "A run cannot skip validation, proof, submission, and reconciliation."
+    },
+    {
+      "from": "submitted",
+      "to": "draft",
+      "reason": "Submitted runs cannot move backward to draft."
+    },
+    {
+      "from": "completed",
+      "to": "failed",
+      "reason": "Completed is terminal and immutable."
+    },
+    {
+      "from": "cancelled",
+      "to": "submitted",
+      "reason": "Cancelled is terminal and immutable."
+    }
+  ],
+  "contract_entrypoints": {
+    "prepare_payroll_run": "submitted",
+    "cancel_payroll_run": "cancelled",
+    "batch_process_payroll": "reconciliation_required",
+    "update_reconciliation_status_reconciled": "completed",
+    "update_reconciliation_status_unreconciled": "reconciliation_required",
+    "update_reconciliation_status_failed": "failed",
+    "get_payroll_run_state": "read_only",
+    "transition_payroll_run_state": "admin_only_conformance_transition"
+  },
+  "future_addition_checklist": [
+    "Update PayrollRunState and the transition table in contracts/payroll/src/lib.rs.",
+    "Add positive and negative contract tests for the new behavior.",
+    "Update this fixture for SDK and dashboard mirrors.",
+    "Update docs/payroll-state-machine.md with initiators and user-visible semantics."
+  ]
+}


### PR DESCRIPTION
Closes #159

## Summary
- Add canonical PayrollRunState lifecycle metadata and guarded transition checks in the payroll contract.
- Persist canonical payroll states from prepare, cancel, execution, and reconciliation flows.
- Add positive and negative contract coverage for valid transitions, forbidden transitions, terminal immutability, retryable failed state behavior, and admin-only state mutation.
- Add shared JSON fixture and documentation for SDK/dashboard conformance.

## Tests
- git diff --check
- JSON fixture parsed with PowerShell ConvertFrom-Json
- cargo fmt: blocked locally by Windows Application Control policy (os error 4551)
- cargo test -p payroll --offline: blocked locally by Windows Application Control policy while running dependency build scripts (os error 4551)