### PR TITLE
feat(events): add high-priority contract events for treasury updates (#168)

### DIFF
--- a/PR_DESCRIPTION_168.md
+++ b/PR_DESCRIPTION_168.md
@@ -1,0 +1,22 @@
+# [Events] Add high-priority contract events for treasury updates (#168)
+
+## Summary
+
+Adds structured contract events when treasury accounts, asset allowlists, or authorization settings are updated across contracts (`payroll_registry` and `payment_executor`). This ensures indexers, dashboards, and audit log monitoring systems receive real-time updates on critical treasury mutations.
+
+## Changes
+
+- **`contracts/payroll_registry/src/lib.rs`**:
+  - Emits `TreasuryRotationProposed` event in `propose_treasury_rotation` with topics `("TreasuryRotationProposed", company_id)` and data `(current_admin, new_treasury, timestamp)`.
+  - Emits `TreasuryRotated` event in `accept_treasury_rotation` with topics `("TreasuryRotated", company_id)` and data `(old_treasury, new_treasury)`.
+  - Implements `cancel_treasury_rotation` in `PayrollRegistryTrait` and `PayrollRegistry` and emits `TreasuryRotationCancelled` event with topics `("TreasuryRotationCancelled", company_id)` and data `(current_admin,)`.
+- **`contracts/payroll_registry/src/tests.rs`**:
+  - Added unit tests for `TreasuryRotationProposed`, `TreasuryRotated`, and `TreasuryRotationCancelled` event emissions and assertions.
+- **`contracts/payment_executor/src/lib.rs`**:
+  - Emits `TreasuryAssetAllowedUpdated` event in `initialize` when setting the default allowed asset token.
+  - Emits `TreasuryAssetAllowedUpdated` event in `set_asset_allowed` with topics `("TreasuryAssetAllowedUpdated", asset)` and data `(allowed, timestamp)`.
+  - Added unit test `test_asset_allowed_emits_events` verifying event published on `initialize` and `set_asset_allowed`.
+
+## Closes
+
+Closes #168

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -8,7 +8,7 @@ use payroll_registry::{CompanyInfo, PayrollRegistryClient};
 use proof_verifier::{Groth16Proof, ProofVerifierClient};
 use salary_commitment::SalaryCommitmentContractClient;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env,
+    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Symbol,
 };
 
 /// Maximum age for a proof relative to its period creation time (7 days in seconds).
@@ -139,6 +139,14 @@ impl PaymentExecutor {
         env.storage()
             .persistent()
             .set(&DataKey::StorageVersion, &1u32);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "TreasuryAssetAllowedUpdated"),
+                addresses.token.clone(),
+            ),
+            (true, env.ledger().timestamp()),
+        );
     }
 
 
@@ -176,7 +184,15 @@ impl PaymentExecutor {
         admin.require_auth();
         env.storage()
             .persistent()
-            .set(&DataKey::AllowedAsset(asset), &allowed);
+            .set(&DataKey::AllowedAsset(asset.clone()), &allowed);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "TreasuryAssetAllowedUpdated"),
+                asset,
+            ),
+            (allowed, env.ledger().timestamp()),
+        );
     }
 
     /// Check if an asset token is allowlisted for payments (issue #175).
@@ -1334,4 +1350,36 @@ mod tests {
 
         assert_eq!(client.get_storage_version(), 1);
     }
+
+    #[test]
+    fn test_asset_allowed_emits_events() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, PaymentExecutor);
+        let client = PaymentExecutorClient::new(&env, &contract_id);
+
+        let addresses = setup_addresses(&env);
+        let before_init = env.events().all().len();
+        client.initialize(&addresses);
+        let after_init = env.events().all().len();
+        assert_eq!(after_init, before_init + 1);
+
+        let init_event = env.events().all().get(after_init - 1).unwrap();
+        let sym0: Symbol = init_event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
+        assert_eq!(sym0, Symbol::new(&env, "TreasuryAssetAllowedUpdated"));
+
+        let executor_admin = Address::generate(&env);
+        client.set_executor_admin(&executor_admin);
+
+        let before_set = env.events().all().len();
+        let new_asset = Address::generate(&env);
+        client.set_asset_allowed(&new_asset, &true);
+        let after_set = env.events().all().len();
+        assert_eq!(after_set, before_set + 1);
+
+        let set_event = env.events().all().get(after_set - 1).unwrap();
+        let set_sym0: Symbol = set_event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
+        assert_eq!(set_sym0, Symbol::new(&env, "TreasuryAssetAllowedUpdated"));
+    }
 }
+

--- a/contracts/payroll_registry/src/lib.rs
+++ b/contracts/payroll_registry/src/lib.rs
@@ -158,6 +158,9 @@ pub trait PayrollRegistryTrait {
 
     /// Accept a pending treasury rotation (step 2 of 2).
     fn accept_treasury_rotation(env: Env, company_id: u64, new_treasury: Address);
+
+    /// Cancel a pending treasury rotation.
+    fn cancel_treasury_rotation(env: Env, company_id: u64, current_admin: Address);
 }
 
 // ---------------------------------------------------------------------------
@@ -628,13 +631,18 @@ impl PayrollRegistryTrait for PayrollRegistry {
         }
 
         let proposal = PendingCompanyRotation {
-            new_holder: new_treasury,
-            proposed_by: current_admin,
+            new_holder: new_treasury.clone(),
+            proposed_by: current_admin.clone(),
             proposed_at: env.ledger().timestamp(),
         };
         env.storage()
             .persistent()
             .set(&DataKey::PendingTreasuryRotation(company_id), &proposal);
+
+        env.events().publish(
+            (Symbol::new(&env, "TreasuryRotationProposed"), company_id),
+            (current_admin, new_treasury, env.ledger().timestamp()),
+        );
     }
 
     fn accept_treasury_rotation(env: Env, company_id: u64, new_treasury: Address) {
@@ -656,13 +664,49 @@ impl PayrollRegistryTrait for PayrollRegistry {
             .get(&DataKey::Company(company_id))
             .expect("Company not found");
 
-        info.treasury = new_treasury;
+        let old_treasury = info.treasury.clone();
+
+        info.treasury = new_treasury.clone();
         env.storage()
             .persistent()
             .set(&DataKey::Company(company_id), &info);
         env.storage()
             .persistent()
             .remove(&DataKey::PendingTreasuryRotation(company_id));
+
+        env.events().publish(
+            (Symbol::new(&env, "TreasuryRotated"), company_id),
+            (old_treasury, new_treasury),
+        );
+    }
+
+    fn cancel_treasury_rotation(env: Env, company_id: u64, current_admin: Address) {
+        Self::require_not_paused(&env);
+        let info: CompanyInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Company(company_id))
+            .expect("Company not found");
+        if current_admin != info.admin {
+            panic!("Unauthorized");
+        }
+        current_admin.require_auth();
+
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::PendingTreasuryRotation(company_id))
+        {
+            panic!("No pending treasury rotation to cancel");
+        }
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingTreasuryRotation(company_id));
+
+        env.events().publish(
+            (Symbol::new(&env, "TreasuryRotationCancelled"), company_id),
+            (current_admin,),
+        );
     }
 }
 

--- a/contracts/payroll_registry/src/tests.rs
+++ b/contracts/payroll_registry/src/tests.rs
@@ -770,3 +770,74 @@ fn test_admin_cannot_accept_treasury_rotation_in_place_of_proposed_treasury() {
     client.propose_treasury_rotation(&company_id, &admin, &new_treasury);
     client.accept_treasury_rotation(&company_id, &admin);
 }
+
+#[test]
+fn test_propose_treasury_rotation_emits_event() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let company_id = client.register_company(&admin, &treasury);
+    let new_treasury = Address::generate(&env);
+
+    let before = env.events().all().len();
+    client.propose_treasury_rotation(&company_id, &admin, &new_treasury);
+    let after = env.events().all().len();
+    assert_eq!(after, before + 1);
+
+    let event = env.events().all().get(after - 1).unwrap();
+    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(sym0, Symbol::new(&env, "TreasuryRotationProposed"));
+    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(comp_id, company_id);
+}
+
+#[test]
+fn test_accept_treasury_rotation_emits_event() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let company_id = client.register_company(&admin, &treasury);
+    let new_treasury = Address::generate(&env);
+
+    client.propose_treasury_rotation(&company_id, &admin, &new_treasury);
+
+    let before = env.events().all().len();
+    client.accept_treasury_rotation(&company_id, &new_treasury);
+    let after = env.events().all().len();
+    assert_eq!(after, before + 1);
+
+    let event = env.events().all().get(after - 1).unwrap();
+    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(sym0, Symbol::new(&env, "TreasuryRotated"));
+    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(comp_id, company_id);
+
+    let company = client.get_company(&company_id);
+    assert_eq!(company.treasury, new_treasury);
+}
+
+#[test]
+fn test_cancel_treasury_rotation_emits_event() {
+    let (env, contract_id) = setup();
+    let client = PayrollRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let company_id = client.register_company(&admin, &treasury);
+    let new_treasury = Address::generate(&env);
+
+    client.propose_treasury_rotation(&company_id, &admin, &new_treasury);
+
+    let before = env.events().all().len();
+    client.cancel_treasury_rotation(&company_id, &admin);
+    let after = env.events().all().len();
+    assert_eq!(after, before + 1);
+
+    let event = env.events().all().get(after - 1).unwrap();
+    let sym0: Symbol = event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(sym0, Symbol::new(&env, "TreasuryRotationCancelled"));
+    let comp_id: u64 = event.1.get(1).unwrap().try_into_val(&env.clone()).unwrap();
+    assert_eq!(comp_id, company_id);
+}
+

--- a/tests/migrations/src/migration_helpers.rs
+++ b/tests/migrations/src/migration_helpers.rs
@@ -351,12 +351,12 @@ impl MigrationContext {
         // Re-deploy all contracts as if new WASM was uploaded.
         // This simulates upgrading to a new contract version while preserving
         // existing storage (old keys remain).
-        let new_registry_id = env.register_contract(Some(self.registry_id.clone()), PayrollRegistry);
-        let new_commitment_id = env.register_contract(Some(self.commitment_id.clone()), SalaryCommitmentContract);
-        let new_verifier_id = env.register_contract(Some(self.verifier_id.clone()), ProofVerifier);
-        let new_payroll_id = env.register_contract(Some(self.payroll_id.clone()), Payroll);
-        let new_executor_id = env.register_contract(Some(self.executor_id.clone()), PaymentExecutor);
-        let new_audit_id = env.register_contract(Some(self.audit_id.clone()), AuditModule);
+        let new_registry_id = env.register_contract(&Some(self.registry_id.clone()), PayrollRegistry);
+        let new_commitment_id = env.register_contract(&Some(self.commitment_id.clone()), SalaryCommitmentContract);
+        let new_verifier_id = env.register_contract(&Some(self.verifier_id.clone()), ProofVerifier);
+        let new_payroll_id = env.register_contract(&Some(self.payroll_id.clone()), Payroll);
+        let new_executor_id = env.register_contract(&Some(self.executor_id.clone()), PaymentExecutor);
+        let new_audit_id = env.register_contract(&Some(self.audit_id.clone()), AuditModule);
 
         // Update IDs to new instances (same contract IDs, new WASM)
         // In Soroban, register_contract with Some(id) deploys to the same address.

--- a/tests/migrations/src/migration_tests.rs
+++ b/tests/migrations/src/migration_tests.rs
@@ -454,9 +454,7 @@ mod migration_tests {
         assert!(!p2.closed, "Period 2 must remain open");
 
         // New periods can be created post-migration
-        let new_period = executor_client.create_period(&ctx.company_id_2);
-        assert!(new_period.is_ok(), "New period creation must work after migration");
-        let new_p = new_period.unwrap();
+        let new_p = executor_client.create_period(&ctx.company_id_2);
         assert_eq!(new_p.period_id, 2, "Period sequence must continue");
         assert_eq!(new_p.company_id, ctx.company_id_2);
         assert!(!new_p.closed);


### PR DESCRIPTION
# [Events] Add high-priority contract events for treasury updates (#168)

## Summary

Adds structured contract events when treasury accounts, asset allowlists, or authorization settings are updated across contracts (`payroll_registry` and `payment_executor`). This ensures indexers, dashboards, and audit log monitoring systems receive real-time updates on critical treasury mutations.

## Changes

- **`contracts/payroll_registry/src/lib.rs`**:
  - Emits `TreasuryRotationProposed` event in `propose_treasury_rotation` with topics `("TreasuryRotationProposed", company_id)` and data `(current_admin, new_treasury, timestamp)`.
  - Emits `TreasuryRotated` event in `accept_treasury_rotation` with topics `("TreasuryRotated", company_id)` and data `(old_treasury, new_treasury)`.
  - Implements `cancel_treasury_rotation` in `PayrollRegistryTrait` and `PayrollRegistry` and emits `TreasuryRotationCancelled` event with topics `("TreasuryRotationCancelled", company_id)` and data `(current_admin,)`.
- **`contracts/payroll_registry/src/tests.rs`**:
  - Added unit tests for `TreasuryRotationProposed`, `TreasuryRotated`, and `TreasuryRotationCancelled` event emissions and assertions.
- **`contracts/payment_executor/src/lib.rs`**:
  - Emits `TreasuryAssetAllowedUpdated` event in `initialize` when setting the default allowed asset token.
  - Emits `TreasuryAssetAllowedUpdated` event in `set_asset_allowed` with topics `("TreasuryAssetAllowedUpdated", asset)` and data `(allowed, timestamp)`.
  - Added unit test `test_asset_allowed_emits_events` verifying event published on `initialize` and `set_asset_allowed`.

## Closes

Closes #168
