### PR TITLE
fix: add dependency updates and reject empty batches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -65,6 +65,8 @@ pub enum PaymentError {
     PeriodAlreadyExists = 6,
     /// The proof has expired and can no longer be used (issue #77).
     ProofExpired = 7,
+    /// Empty payroll batches are rejected to avoid silent no-op execution.
+    EmptyBatch = 8,
 }
 
 /// Contract addresses for dependencies
@@ -464,6 +466,10 @@ impl PaymentExecutor {
             || nullifiers.len() != count
         {
             return Err(PaymentError::ArrayLengthMismatch);
+        }
+
+        if count == 0 {
+            return Err(PaymentError::EmptyBatch);
         }
 
         let mut records = soroban_sdk::Vec::new(&env);

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -866,6 +866,10 @@ impl Payroll {
             panic!("Array length mismatch");
         }
 
+        if count == 0 {
+            panic!("Empty payroll batch");
+        }
+
         assert!(count <= MAX_BATCH, "Batch too large");
 
         // Reject duplicate run nonces before any other work.
@@ -1002,6 +1006,10 @@ impl Payroll {
 
         if amounts.len() != count || employees.len() != count {
             panic!("Array length mismatch");
+        }
+
+        if count == 0 {
+            panic!("Empty payroll batch");
         }
 
         assert!(count <= MAX_BATCH, "Batch too large");


### PR DESCRIPTION
Closes #6
Closes #216

## Summary
- Added GitHub Dependabot configuration for weekly Cargo and npm dependency checks.
- Added explicit empty payroll batch rejection in the high-level Payroll contract.
- Added empty batch rejection to the PaymentExecutor batch flow using a dedicated `EmptyBatch` error.

## Notes
This intentionally covers a scoped portion of #216 by adding the contract-side rejection guard. Test coverage was not added in this pass.

## Testing
Not run, per request.