### PR TITLE
fix: enforce commitment uniqueness, settlement replay guard, and role…

### DIFF
--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -1387,5 +1387,119 @@ mod tests {
         let set_sym0: Symbol = set_event.1.get(0).unwrap().try_into_val(&env.clone()).unwrap();
         assert_eq!(set_sym0, Symbol::new(&env, "TreasuryAssetAllowedUpdated"));
     }
+
+    // ── Issue #245: operator vs admin role separation ─────────────────────────
+    //
+    // `payment_executor` has two distinct privileged roles that must not be
+    // conflated: the protocol-level `ExecutorAdmin` (gates contract-wide
+    // config: `set_asset_allowed`, `set_pause_manager`) and each company's
+    // own `admin` (gates that company's periods and payments only — the
+    // "operator" of its own payroll). Neither role should be able to
+    // exercise the other's capabilities.
+
+    /// A company admin (this company's payroll "operator") must not be able
+    /// to exercise the protocol-level `ExecutorAdmin` capability of changing
+    /// the treasury asset allowlist just because they administer a company.
+    #[test]
+    #[should_panic(expected = "authorized")]
+    fn test_company_admin_cannot_set_asset_allowed() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, PaymentExecutor);
+        let client = PaymentExecutorClient::new(&env, &contract_id);
+
+        let addresses = setup_addresses(&env);
+        client.initialize(&addresses);
+
+        let executor_admin = Address::generate(&env);
+        client.set_executor_admin(&executor_admin);
+
+        let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let company_admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let _company_id = registry_client.register_company(&company_admin, &treasury);
+
+        // Company admin (not the executor admin) attempts a protocol-level
+        // config change.
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &company_admin,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_asset_allowed",
+                args: (addresses.token.clone(), false).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.set_asset_allowed(&addresses.token, &false);
+    }
+
+    /// The protocol-level `ExecutorAdmin` must not be able to trigger payroll
+    /// execution for a company it does not administer — that capability
+    /// belongs solely to the company's own admin.
+    #[test]
+    #[should_panic(expected = "authorized")]
+    fn test_executor_admin_cannot_execute_payment_for_foreign_company() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, PaymentExecutor);
+        let client = PaymentExecutorClient::new(&env, &contract_id);
+
+        let addresses = setup_addresses(&env);
+        client.initialize(&addresses);
+
+        let executor_admin = Address::generate(&env);
+        client.set_executor_admin(&executor_admin);
+
+        let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &addresses.commitment);
+        let token_client = TokenClient::new(&env, &addresses.token);
+
+        let company_admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let company_id = registry_client.register_company(&company_admin, &treasury);
+
+        let employee = Address::generate(&env);
+        let commitment = BytesN::from_array(&env, &[5u8; 32]);
+        commitment_client.store_commitment(&employee, &commitment);
+        registry_client.add_employee(&company_id, &employee, &commitment);
+        token_client.mint(&treasury, &100_000i128);
+
+        client.create_period(&company_id);
+
+        let proof_a = BytesN::from_array(&env, &[1u8; 64]);
+        let proof_b = BytesN::from_array(&env, &[2u8; 128]);
+        let proof_c = BytesN::from_array(&env, &[3u8; 64]);
+        let nullifier = BytesN::from_array(&env, &[4u8; 32]);
+
+        // Executor admin (not this company's admin) attempts to execute a
+        // payment for a company it does not administer.
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &executor_admin,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "execute_payment",
+                args: (
+                    company_id,
+                    employee.clone(),
+                    1000i128,
+                    proof_a.clone(),
+                    proof_b.clone(),
+                    proof_c.clone(),
+                    nullifier.clone(),
+                    1u32,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let _ = client.execute_payment(
+            &company_id,
+            &employee,
+            &1000i128,
+            &proof_a,
+            &proof_b,
+            &proof_c,
+            &nullifier,
+            &1u32,
+        );
+    }
 }
 

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -1296,10 +1296,18 @@ impl Payroll {
             .get(&run_key)
             .expect("Run not found");
 
+        // Issue #244: settlement completion is final. Once a run has reached
+        // `Completed`, reject any further reconciliation update — including a
+        // repeat `Reconciled` call — so settlement cannot be replayed or
+        // finalized more than once for the same payroll run.
+        let current_state = Self::get_payroll_run_state_internal(&e, run_id);
+        if current_state == PayrollRunState::Completed {
+            panic!("Settlement already finalized: run is Completed and cannot be updated again");
+        }
+
         run.reconciliation_status = status.clone();
         e.storage().persistent().set(&run_key, &run);
 
-        let current_state = Self::get_payroll_run_state_internal(&e, run_id);
         let next_state = match status {
             ReconciliationStatus::Reconciled => PayrollRunState::Completed,
             ReconciliationStatus::Unreconciled => PayrollRunState::ReconciliationRequired,
@@ -1877,7 +1885,10 @@ mod tests {
             proofs.push_back(p);
             amounts.push_back(100i128 + i as i128);
             let emp = Address::generate(&env);
-            commitment_client.store_commitment(&emp, &BytesN::from_array(&env, &[0u8; 32]));
+            let mut cmt_bytes = [0u8; 32];
+            cmt_bytes[0] = (i % 256) as u8;
+            cmt_bytes[1] = (i / 256) as u8;
+            commitment_client.store_commitment(&emp, &BytesN::from_array(&env, &cmt_bytes));
             employees.push_back(emp);
         }
 
@@ -2611,6 +2622,50 @@ mod tests {
             &ReconciliationStatus::Failed,
         );
         assert!(result.is_err(), "Completed runs must not be reopened");
+    }
+
+    // ── Issue #244: payroll settlement replay guard ──────────────────────────
+
+    /// A repeat `Reconciled` call for an already-`Completed` run must be
+    /// rejected, not silently re-accepted. Before this guard, calling
+    /// `update_reconciliation_status` twice with the same terminal status
+    /// bypassed the transition check (current == next state) and replayed
+    /// the settlement-completion event.
+    #[test]
+    fn test_reconciled_run_cannot_be_replayed() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&env, 220),
+            &None,
+        );
+
+        payroll_client.update_reconciliation_status(
+            &admin,
+            &run_id,
+            &ReconciliationStatus::Reconciled,
+        );
+        assert_eq!(
+            payroll_client.get_payroll_run_state(&run_id),
+            PayrollRunState::Completed
+        );
+
+        let result = payroll_client.try_update_reconciliation_status(
+            &admin,
+            &run_id,
+            &ReconciliationStatus::Reconciled,
+        );
+        assert!(
+            result.is_err(),
+            "Settlement completion must not be replayable for a Completed run"
+        );
     }
 
     #[test]

--- a/contracts/salary_commitment/src/lib.rs
+++ b/contracts/salary_commitment/src/lib.rs
@@ -77,6 +77,12 @@ pub enum DataKey {
     /// Set by the admin via `lock_commitment_updates` and cleared via
     /// `unlock_commitment_updates`.
     CommitmentLock(Address),
+    /// Marks a commitment value as already bound to an employee, active or
+    /// archived (issue #242). Once set it is never cleared: a commitment
+    /// value that has participated in any active or completed payroll run
+    /// must never be reassigned to a different (or the same) employee, since
+    /// reuse would weaken privacy assumptions and confuse reconciliation.
+    CommitmentIndex(BytesN<32>),
     /// Pause manager address (issue #193).
     PauseManager,
     /// Pending admin rotation proposal (issue #192).
@@ -168,6 +174,9 @@ impl SalaryCommitmentContract {
 
     /// Store a new salary commitment for an employee.
     /// Only the HR admin may call.
+    ///
+    /// The commitment value must be globally unique (issue #242): it cannot
+    /// already be bound to any employee, active or archived.
     pub fn store_commitment(
         env: Env,
         employee: Address,
@@ -175,6 +184,7 @@ impl SalaryCommitmentContract {
     ) -> SalaryCommitment {
         Self::require_not_paused(&env);
         Self::require_admin(&env);
+        Self::register_commitment_uniqueness(&env, &commitment);
 
         let timestamp = env.ledger().timestamp();
 
@@ -227,6 +237,8 @@ impl SalaryCommitmentContract {
             .persistent()
             .get(&key)
             .expect("Commitment not found");
+
+        Self::register_commitment_uniqueness(&env, &new_commitment);
 
         // Archive current commitment before replacing
         Self::archive_commitment(&env, &employee, &existing.commitment, existing.version);
@@ -611,6 +623,16 @@ impl SalaryCommitmentContract {
         }
     }
 
+    /// Reject a commitment value that has already been bound to any
+    /// employee (active or archived) and register it as used (issue #242).
+    fn register_commitment_uniqueness(env: &Env, commitment: &BytesN<32>) {
+        let key = DataKey::CommitmentIndex(commitment.clone());
+        if env.storage().persistent().has(&key) {
+            panic!("Commitment already in use: commitments must be unique across employees and payroll runs");
+        }
+        env.storage().persistent().set(&key, &true);
+    }
+
     fn archive_commitment(env: &Env, employee: &Address, commitment: &BytesN<32>, version: u32) {
         let mut idx: u32 = 0;
         loop {
@@ -686,6 +708,67 @@ mod tests {
 
         assert_eq!(result.commitment, updated);
         assert_eq!(result.version, 2);
+    }
+
+    // ── Issue #242: payroll commitment uniqueness enforcement ────────────────
+
+    /// The same commitment value must not be assignable to two different
+    /// employees — reuse would weaken privacy assumptions (two employees
+    /// appearing to share the same salary + blinding factor) and confuse
+    /// reconciliation.
+    #[test]
+    #[should_panic(expected = "Commitment already in use")]
+    fn test_duplicate_commitment_rejected_for_different_employee() {
+        let (env, contract_id, _admin) = setup_with_admin();
+        let client = SalaryCommitmentContractClient::new(&env, &contract_id);
+
+        let employee_a = Address::generate(&env);
+        let employee_b = Address::generate(&env);
+        let commitment = BytesN::from_array(&env, &[7u8; 32]);
+
+        client.store_commitment(&employee_a, &commitment);
+        client.store_commitment(&employee_b, &commitment);
+    }
+
+    /// Rotating or updating a commitment to a value already bound to another
+    /// employee must be rejected the same way as `store_commitment`.
+    #[test]
+    #[should_panic(expected = "Commitment already in use")]
+    fn test_update_commitment_rejects_value_already_used_elsewhere() {
+        let (env, contract_id, _admin) = setup_with_admin();
+        let client = SalaryCommitmentContractClient::new(&env, &contract_id);
+
+        let employee_a = Address::generate(&env);
+        let employee_b = Address::generate(&env);
+        let commitment_a = BytesN::from_array(&env, &[8u8; 32]);
+        let commitment_b = BytesN::from_array(&env, &[9u8; 32]);
+
+        client.store_commitment(&employee_a, &commitment_a);
+        client.store_commitment(&employee_b, &commitment_b);
+
+        // Attempt to rotate employee B onto employee A's active commitment.
+        client.update_commitment(&employee_b, &commitment_a);
+    }
+
+    /// A commitment value that was rotated out (archived) can never be
+    /// reused, even by a brand-new employee — it must remain retired for
+    /// the lifetime of the contract (issue #242).
+    #[test]
+    #[should_panic(expected = "Commitment already in use")]
+    fn test_archived_commitment_cannot_be_reused() {
+        let (env, contract_id, _admin) = setup_with_admin();
+        let client = SalaryCommitmentContractClient::new(&env, &contract_id);
+
+        let employee = Address::generate(&env);
+        let new_employee = Address::generate(&env);
+        let old_commitment = BytesN::from_array(&env, &[10u8; 32]);
+        let new_commitment = BytesN::from_array(&env, &[11u8; 32]);
+
+        client.store_commitment(&employee, &old_commitment);
+        client.rotate_commitment(&employee, &new_commitment);
+
+        // old_commitment is now archived/revoked but must remain retired.
+        client.store_commitment(&new_employee, &old_commitment);
     }
 
     #[test]
@@ -972,14 +1055,15 @@ mod tests {
         let existing_emp = Address::generate(&env);
         let new_emp = Address::generate(&env);
         let cmt = BytesN::from_array(&env, &[15u8; 32]);
+        let other_cmt = BytesN::from_array(&env, &[16u8; 32]);
 
         client.store_commitment(&existing_emp, &cmt);
         client.lock_commitment_updates(&existing_emp);
 
-        // A new employee should still be able to get a commitment stored
-        let result = client.store_commitment(&new_emp, &cmt);
+        // A new employee should still be able to get a (distinct) commitment stored
+        let result = client.store_commitment(&new_emp, &other_cmt);
         assert_eq!(result.version, 1);
-        assert_eq!(result.commitment, cmt);
+        assert_eq!(result.commitment, other_cmt);
     }
 
     /// A stranger who is neither the admin nor the delegated operator must

--- a/docs/deployment-verification.md
+++ b/docs/deployment-verification.md
@@ -21,14 +21,17 @@ All commands use the unified **`stellar`** CLI (the `soroban` CLI is
 equivalent — `soroban contract …` accepts the same subcommands where noted).
 Replace every `<ALL_CAPS>` placeholder with your real value before running.
 
-The five contracts and their release WASM artifacts:
+The seven contracts and their release WASM artifacts, in deployment order (see
+[ops/preflight-deployment-checklist.md §5](ops/preflight-deployment-checklist.md#5-deployment-order)):
 
 | Contract | Struct | WASM artifact |
 |----------|--------|---------------|
 | `payroll_registry` | `PayrollRegistry` | `payroll_registry.wasm` |
 | `salary_commitment` | `SalaryCommitmentContract` | `salary_commitment.wasm` |
 | `proof_verifier` | `ProofVerifier` | `proof_verifier.wasm` |
+| `pause_manager` | `PauseManager` | `pause_manager.wasm` |
 | `payment_executor` | `PaymentExecutor` | `payment_executor.wasm` |
+| `payroll` | `Payroll` | `payroll.wasm` |
 | `audit_module` | `AuditModule` | `audit_module.wasm` |
 
 ---
@@ -67,7 +70,7 @@ export SOURCE=admin
 - [ ] Contract-ID variables, exported as each contract is deployed:
 
 ```bash
-export TOKEN_ID=<TOKEN_CONTRACT_ID> REGISTRY_ID=<REGISTRY_CONTRACT_ID> COMMITMENT_ID=<COMMITMENT_CONTRACT_ID> VERIFIER_ID=<VERIFIER_CONTRACT_ID> EXECUTOR_ID=<EXECUTOR_CONTRACT_ID> AUDIT_ID=<AUDIT_CONTRACT_ID>
+export TOKEN_ID=<TOKEN_CONTRACT_ID> REGISTRY_ID=<REGISTRY_CONTRACT_ID> COMMITMENT_ID=<COMMITMENT_CONTRACT_ID> VERIFIER_ID=<VERIFIER_CONTRACT_ID> PAUSE_ID=<PAUSE_MANAGER_CONTRACT_ID> EXECUTOR_ID=<EXECUTOR_CONTRACT_ID> PAYROLL_ID=<PAYROLL_CONTRACT_ID> AUDIT_ID=<AUDIT_CONTRACT_ID>
 ```
 
 ### Network config verification
@@ -128,9 +131,9 @@ stellar keys address $SOURCE
 
 ## 2. Contract Deployment Verification
 
-Run these for **each of the five contracts**. Repeat the block substituting the
+Run these for **each of the seven contracts**. Repeat the block substituting the
 matching contract-ID variable (`$REGISTRY_ID`, `$COMMITMENT_ID`,
-`$VERIFIER_ID`, `$EXECUTOR_ID`, `$AUDIT_ID`).
+`$VERIFIER_ID`, `$PAUSE_ID`, `$EXECUTOR_ID`, `$PAYROLL_ID`, `$AUDIT_ID`).
 
 ### 2.1 Confirm the contract was deployed
 
@@ -155,10 +158,22 @@ stellar contract fetch --id $COMMITMENT_ID --network $NETWORK --out-file /tmp/fe
 stellar contract fetch --id $VERIFIER_ID --network $NETWORK --out-file /tmp/fetched_verifier.wasm
 ```
 
+- [ ] `pause_manager` deployed:
+
+```bash
+stellar contract fetch --id $PAUSE_ID --network $NETWORK --out-file /tmp/fetched_pause_manager.wasm
+```
+
 - [ ] `payment_executor` deployed:
 
 ```bash
 stellar contract fetch --id $EXECUTOR_ID --network $NETWORK --out-file /tmp/fetched_executor.wasm
+```
+
+- [ ] `payroll` deployed:
+
+```bash
+stellar contract fetch --id $PAYROLL_ID --network $NETWORK --out-file /tmp/fetched_payroll.wasm
 ```
 
 - [ ] `audit_module` deployed:
@@ -223,6 +238,21 @@ stellar contract invoke --id $EXECUTOR_ID --source $SOURCE --network $NETWORK --
 
 **Expected output:** `true` (the token passed into `initialize` is
 auto-allowlisted).
+
+- [ ] **`pause_manager`** — `initialize(operator)` has been called exactly
+  once (panics `Already initialized` on repeat). Confirm via `is_paused`:
+
+```bash
+stellar contract invoke --id $PAUSE_ID --source $SOURCE --network $NETWORK -- is_paused
+```
+
+**Expected output:** `false` on a fresh deploy.
+
+- [ ] **`payroll`** — `initialize(admin, token, verifier, commitment, treasury,
+  treasury_owner)` has been called (panics `Already initialized` on repeat)
+  and the run counter starts at `0`. `set_pause_manager(pause_manager)` has
+  been wired if pausability is required. Confirm via the indirect admin check
+  in §3.6 (there is no `get_addresses` getter).
 
 - [ ] **`audit_module`** — has no admin-init entrypoint; the view-key granter is
   the contract's own address. State begins empty (`get_audit_log_count`
@@ -302,6 +332,44 @@ stellar contract invoke --id $AUDIT_ID --source $SOURCE --network $NETWORK -- ge
 ```
 
 **Expected output:** `0` on a fresh deploy.
+
+### 3.6 `payroll` admin
+
+`payroll` stores its `ContractAddresses` (including `admin`) but exposes
+**no getter**. Verify indirectly, the same way as §3.3:
+
+- [ ] Confirm an admin-gated call succeeds only for the real admin — invoking
+  `commit_draft` as `$SOURCE` should succeed if `$SOURCE` is the payroll admin,
+  and fail with an authorization error otherwise:
+
+```bash
+stellar contract invoke --id $PAYROLL_ID --source $SOURCE --network $NETWORK -- commit_draft --admin $(stellar keys address $SOURCE) --draft_hash 0000000000000000000000000000000000000000000000000000000000000000
+```
+
+**Expected output:** succeeds when `$SOURCE` is the payroll admin; an
+authorization error confirms `$SOURCE` is not admin.
+
+### 3.7 `pause_manager` operator
+
+`pause_manager` stores the operator address but exposes no getter for it
+either. Do **not** invoke `pause` / `unpause` against a live deployment just to
+test authorization — that would actually pause the system. Instead confirm the
+operator indirectly via a reversible call:
+
+- [ ] Propose (and then cancel) an operator rotation as `$SOURCE` — this
+  requires the caller to already be the current operator and has no
+  side effect on the paused/unpaused state:
+
+```bash
+stellar contract invoke --id $PAUSE_ID --source $SOURCE --network $NETWORK -- propose_operator_rotation --current_operator $(stellar keys address $SOURCE) --new_operator $(stellar keys address $SOURCE)
+```
+
+```bash
+stellar contract invoke --id $PAUSE_ID --source $SOURCE --network $NETWORK -- cancel_operator_rotation --current_operator $(stellar keys address $SOURCE)
+```
+
+**Expected output:** both calls succeed when `$SOURCE` is the operator; an
+authorization error on the first call confirms `$SOURCE` is not the operator.
 
 ---
 
@@ -440,6 +508,20 @@ window.)
   `PayrollProcessed` event and balance movement. This is beyond a basic smoke
   test — see [sdk-contract-interface.md](sdk-contract-interface.md) Flow 3.
 
+- [ ] **(Optional) `payroll` batch path wiring.** If the deployment also uses
+  the nonce-based `payroll` contract (a separate execution path from
+  `payment_executor`), confirm `salary_commitment`'s delegated operator is the
+  `payroll` contract address:
+
+```bash
+stellar contract invoke --id $COMMITMENT_ID --source $SOURCE --network $NETWORK -- get_payroll_operator
+```
+
+**Expected output:** `"$PAYROLL_ID"`. A mismatch means `set_payroll_operator`
+was not called against `payroll`'s deployed address (see preflight checklist
+step 8), and `payroll`'s `batch_process_payroll` will fail to record
+nullifiers or lock commitments.
+
 ---
 
 ## 6. Rollback Procedure
@@ -459,8 +541,8 @@ stellar contract invoke --id $EXECUTOR_ID --source $SOURCE --network $NETWORK --
 ```
 
   Then trigger the pause on the pause manager itself (see the pause manager's
-  own interface). The registry, salary_commitment, and audit_module each also
-  expose `set_pause_manager` for the same purpose.
+  own interface). The registry, salary_commitment, payroll, and audit_module
+  each also expose `set_pause_manager` for the same purpose.
 - [ ] **Capture diagnostics:** record the failing command, the contract ID,
   and the full error/panic message for the incident log (see
   [incident-response-playbook.md](incident-response-playbook.md)).


### PR DESCRIPTION
  ## Summary
  
  Resolves four contract-hardening issues: payroll commitment uniqueness
  enforcement (#242), a payroll settlement replay guard (#244), operator vs
  admin role-check coverage (#245), and a deployment smoke test checklist gap
  (#246).

  ## Changes
  
  **fix(#242)** — `contracts/salary_commitment/src/lib.rs`
  `store_commitment` and `update_commitment` now reject a commitment value
  that has already been bound to any employee, active or archived (checked via
  a new `CommitmentIndex` reverse-lookup, following the same pattern already
  used by `ReferenceIdIndex`). `rotate_commitment` is covered automatically
  since it delegates its new-value write to `store_commitment`. Without this,
  two employees could be assigned the same commitment, or a rotated-out
  commitment could be reassigned — weakening privacy assumptions and
  confusing reconciliation. Fixed two existing tests that relied on reusing
  placeholder commitment bytes across different employees.

  **fix(#244)** — `contracts/payroll/src/lib.rs`
  `update_reconciliation_status` now rejects any further update once a run has
  reached `Completed`, including a repeat call with the same `Reconciled`
  status. Previously, calling it twice with `Reconciled` bypassed the
  transition guard (`current_state == next_state` short-circuited the check),
  letting the settlement-completion event and state write replay.
  
  **fix(#245)** — `contracts/payment_executor/src/lib.rs`
  Added negative tests proving the two privileged roles in this contract can't
  cross into each other's capabilities: a company admin (that company's
  payroll "operator") cannot call the protocol-level `ExecutorAdmin`-gated
  `set_asset_allowed`, and the `ExecutorAdmin` cannot trigger `execute_payment`
  for a company it doesn't administer. Enforcement already existed via
  Soroban's `require_auth` model; this locks the boundary in with tests so it
  isn't left to convention.

  **fix(#246)** — `docs/deployment-verification.md`
  The existing deployment verification checklist only covered 5 of the
  project's 7 contracts — `payroll` and `pause_manager` were completely
  missing from the contract table, deployment/init verification, admin-role
  verification, and smoke-test sections, even though
  `ops/preflight-deployment-checklist.md` already listed them in the
  deployment order. Extended the checklist to cover both, including indirect
  admin/operator verification (neither contract exposes a getter) and a
  payroll-operator wiring check between `payroll` and `salary_commitment`.

  ## Testing

  ```bash
  cargo check -p salary_commitment -p payroll -p payment_executor
  cargo test -p salary_commitment   # 26 passed
  cargo test -p payroll             # 105 passed
  cargo test -p payment_executor    # 21 passed, 2 pre-existing unrelated failures (verified present on main via
  git stash)
```

  Closes
  
  Closes #242
  Closes #244
  Closes #245
  Closes #246