### PR TITLE
Add configuration locks during active payroll execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "admin_config_lock_tests"
+version = "0.1.0"
+dependencies = [
+ "pause_manager",
+ "payroll",
+ "proof_verifier",
+ "salary_commitment",
+ "soroban-sdk",
+ "token",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +420,17 @@ dependencies = [
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "company_state_gate_tests"
+version = "0.1.0"
+dependencies = [
+ "payroll",
+ "proof_verifier",
+ "salary_commitment",
+ "soroban-sdk",
+ "token",
 ]
 
 [[package]]
@@ -1813,6 +1836,7 @@ name = "payroll"
 version = "0.1.0"
 dependencies = [
  "pause_manager",
+ "payroll_events",
  "payroll_registry",
  "proof_verifier",
  "salary_commitment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["contracts/*", "cli", "tests/migrations"]
+members = ["contracts/*", "cli", "tests/migrations", "tests/admin", "tests/state"]
 exclude = ["fuzz"]
 
 

--- a/contracts/pause_manager/src/lib.rs
+++ b/contracts/pause_manager/src/lib.rs
@@ -248,7 +248,7 @@ impl<'a> PauseManagerClient<'a> {
         self.0.invoke_contract(
             &self.1,
             &Symbol::new(self.0, "get_pending_operator_rotation"),
-            (),
+            Self::empty_args(self.0),
         )
     }
 }

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token as soroban_token, Address, BytesN, Env, Symbol, Vec,
+    contract, contractimpl, contracttype, symbol_short, token as soroban_token, Address, BytesN,
+    Env, Symbol, Vec,
 };
 
 use pause_manager::PauseManagerClient;
@@ -304,6 +305,12 @@ pub enum DataKey {
     CompanyState,
     /// Canonical payroll run state for SDK/dashboard conformance (#159).
     PayrollState(u64),
+    /// Allowlisted payout asset tokens.
+    AllowedAsset(Address),
+    /// Count of payroll runs currently prepared but not yet resolved
+    /// (cancelled). Used to lock unsafe admin configuration changes while a
+    /// run is in progress — see `require_no_active_payroll_run`.
+    PendingRunCount,
     // Future upgrade example (issue #196):
     // PayrollRunV2(u64),  // Would be added here when schema evolution is needed
 }
@@ -389,6 +396,44 @@ impl Payroll {
         }
     }
 
+    fn pending_payroll_run_count(e: &Env) -> u32 {
+        e.storage()
+            .persistent()
+            .get(&DataKey::PendingRunCount)
+            .unwrap_or(0)
+    }
+
+    // Issue #253: configuration locks during active payroll execution.
+    //
+    // A run is "in progress" from the moment `prepare_payroll_run` reserves
+    // its nonce and stores a `PendingPayrollRun` until it is explicitly
+    // resolved via `cancel_payroll_run`. While any run is pending, changing
+    // the acting admin, the treasury owner, the payout asset allowlist, or
+    // the company lifecycle state could silently invalidate assumptions the
+    // run was prepared under (which treasury funds are debited, which asset
+    // pays out, who is authorised to act on it). This gate rejects those
+    // specific changes until every pending run has been cancelled, keeping a
+    // run's preconditions stable for its whole lifetime. It does not block
+    // proposing a rotation (inert until accepted), pausing the system, or
+    // resolving existing runs (`cancel_payroll_run`,
+    // `update_reconciliation_status`), so operators always retain an escape
+    // hatch.
+    fn require_no_active_payroll_run(e: &Env) {
+        if Self::pending_payroll_run_count(e) > 0 {
+            panic!(
+                "Configuration is locked: a payroll run is currently in progress. Cancel all pending runs before changing this setting"
+            );
+        }
+    }
+
+    /// Return `true` if one or more payroll runs are prepared but not yet
+    /// resolved. While `true`, admin configuration changes that could
+    /// undermine those runs (admin rotation, treasury rotation, asset
+    /// allowlist, company state) are rejected (issue #253).
+    pub fn has_active_payroll_run(e: Env) -> bool {
+        Self::pending_payroll_run_count(&e) > 0
+    }
+
     pub fn set_pause_manager(e: Env, pause_manager: Address) {
         let addrs: ContractAddresses = e
             .storage()
@@ -404,6 +449,10 @@ impl Payroll {
     }
 
     /// Allow or disallow an asset token for payroll payouts.
+    ///
+    /// Locked while any payroll run is prepared but not yet resolved (#253):
+    /// changing the payout asset mid-run could redirect or invalidate a run
+    /// that was already validated against the previous allowlist.
     pub fn set_asset_allowed(e: Env, asset: Address, allowed: bool) {
         let addrs: ContractAddresses = e
             .storage()
@@ -411,6 +460,7 @@ impl Payroll {
             .get(&DataKey::Addresses)
             .expect("Not initialized");
         addrs.admin.require_auth();
+        Self::require_no_active_payroll_run(&e);
         e.storage()
             .persistent()
             .set(&DataKey::AllowedAsset(asset), &allowed);
@@ -876,6 +926,8 @@ impl Payroll {
         nonce: BytesN<32>,
         draft_hash: Option<BytesN<32>>,
     ) -> u64 {
+        Self::require_company_active(&e);
+
         let count = proofs.len();
 
         if amounts.len() != count || employees.len() != count {
@@ -953,6 +1005,13 @@ impl Payroll {
             .set(&DataKey::PendingRun(run_id), &pending_run);
         Self::record_payroll_run_state(&e, run_id, PayrollRunState::Submitted);
 
+        // Issue #253: track this run as "in progress" so unsafe admin
+        // configuration changes are locked out until it is resolved.
+        e.storage().persistent().set(
+            &DataKey::PendingRunCount,
+            &(Self::pending_payroll_run_count(&e) + 1),
+        );
+
         payroll_events::emit_run_prepared(&e, run_id, expected_total_spend);
 
         run_id
@@ -961,70 +1020,6 @@ impl Payroll {
     /// Get a pending payroll run, if it exists.
     pub fn get_pending_run(e: Env, run_id: u64) -> Option<PendingPayrollRun> {
         e.storage().persistent().get(&DataKey::PendingRun(run_id))
-    }
-
-    /// Finalize a pending payroll run, executing payments and creating a
-    /// permanent `PayrollRun` record (issue #198).
-    ///
-    /// Only the admin may finalize. The caller must supply the same proofs,
-    /// amounts, and employees that were validated during `prepare_payroll_run`.
-    /// The pending run must exist and its metadata (total_amount, employee_count)
-    /// must match the supplied batch.
-    ///
-    /// Cancellation emits an event for audit trails. Finalized runs cannot be
-    /// cancelled retroactively.
-    ///
-    /// Issue #218: Added explicit validation that the run is still pending
-    /// and proper state cleanup to prevent cancel-after-submit race conditions.
-    pub fn cancel_payroll_run(e: Env, admin: Address, run_id: u64) {
-        Self::require_not_paused(&e);
-        let addrs: ContractAddresses = e
-            .storage()
-            .persistent()
-            .get(&DataKey::Addresses)
-            .expect("Not initialized");
-        if admin != addrs.admin {
-            panic!("Unauthorized");
-        }
-        admin.require_auth();
-
-        let pending_key = DataKey::PendingRun(run_id);
-        let pending_run: PendingPayrollRun = e
-            .storage()
-            .persistent()
-            .get(&pending_key)
-            .expect("Pending run not found");
-
-        // Issue #218: Check if run has already been finalized
-        // Once a run is executed, it cannot be cancelled
-        let run_key = DataKey::PayrollRun(run_id);
-        if e.storage().persistent().has(&run_key) {
-            panic!("Cannot cancel: run has already been executed");
-        }
-
-        // Remove the pending run from storage
-        e.storage().persistent().remove(&pending_key);
-        Self::record_payroll_run_state(&e, run_id, PayrollRunState::Cancelled);
-
-        let run = PayrollRun {
-            run_id,
-            executed_at: e.ledger().timestamp(),
-            admin: addrs.admin.clone(),
-            total_amount: pending_run.total_amount,
-            employee_count: pending_run.employee_count,
-            draft_hash: pending_run.draft_hash.clone(),
-            nonce: pending_run.nonce.clone(),
-            reconciliation_status: ReconciliationStatus::Unreconciled,
-            metadata_hash: BytesN::from_array(&e, &[0u8; 32]),
-        };
-        e.storage()
-            .persistent()
-            .set(&DataKey::PayrollRun(run_id), &run);
-
-        e.events().publish(
-            (symbol_short!("payroll"), Symbol::new(&e, "run_finalized")),
-            (run_id, pending_run.total_amount),
-        );
     }
 
     /// Cancel a pending payroll run without executing any payments (issue #198).
@@ -1067,6 +1062,14 @@ impl Payroll {
 
         // Remove the pending run from storage
         e.storage().persistent().remove(&pending_key);
+        Self::record_payroll_run_state(&e, run_id, PayrollRunState::Cancelled);
+
+        // Issue #253: this run is resolved — release the configuration lock
+        // once no other pending runs remain.
+        e.storage().persistent().set(
+            &DataKey::PendingRunCount,
+            &Self::pending_payroll_run_count(&e).saturating_sub(1),
+        );
 
         // Emit cancellation event with reason for audit trail
         e.events().publish(
@@ -1084,6 +1087,8 @@ impl Payroll {
         nonce: BytesN<32>,
         draft_hash: Option<BytesN<32>>,
     ) -> u64 {
+        Self::require_company_active(&e);
+
         let count = proofs.len();
 
         if amounts.len() != count || employees.len() != count {
@@ -1373,7 +1378,7 @@ impl Payroll {
             panic!("Settlement already finalized: run is Completed and cannot be updated again");
         }
 
-        run.reconciliation_status = status.clone();
+        run.reconciliation_status = status;
         e.storage().persistent().set(&run_key, &run);
 
         let next_state = match status {
@@ -1482,6 +1487,10 @@ impl Payroll {
     ///
     /// Only the proposed new admin can accept. On acceptance the admin in
     /// `ContractAddresses` is updated and the proposal is cleared.
+    ///
+    /// Locked while any payroll run is prepared but not yet resolved (#253):
+    /// handing off administration mid-run could let a party the run was not
+    /// authorised under later act on it.
     pub fn accept_admin_rotation(e: Env, new_admin: Address) {
         Self::require_not_paused(&e);
         let proposal: PendingRotation = e
@@ -1494,6 +1503,7 @@ impl Payroll {
             panic!("Unauthorized: caller is not the proposed admin");
         }
         new_admin.require_auth();
+        Self::require_no_active_payroll_run(&e);
 
         let mut addrs: ContractAddresses = e
             .storage()
@@ -1569,6 +1579,11 @@ impl Payroll {
     }
 
     /// Accept a treasury-owner rotation (step 2 of 2).
+    ///
+    /// Locked while any payroll run is prepared but not yet resolved (#253):
+    /// the treasury owner can request deposits and emergency withdrawals, so
+    /// handing that role to a new party mid-run could let someone who did
+    /// not authorise the run's preconditions move funds while it is pending.
     pub fn accept_treasury_rotation(e: Env, new_owner: Address) {
         Self::require_not_paused(&e);
         let proposal: PendingRotation = e
@@ -1581,6 +1596,7 @@ impl Payroll {
             panic!("Unauthorized: caller is not the proposed treasury owner");
         }
         new_owner.require_auth();
+        Self::require_no_active_payroll_run(&e);
 
         let old_owner: Address = e
             .storage()
@@ -1687,8 +1703,15 @@ impl Payroll {
     /// Set the company lifecycle state.
     ///
     /// Only the admin may call. After setting to anything other than `Active`,
-    /// all subsequent `batch_process_payroll` calls will be rejected with a
-    /// descriptive error until the state is restored to `Active`.
+    /// all subsequent `prepare_payroll_run` and `batch_process_payroll` calls
+    /// will be rejected with a descriptive error until the state is restored
+    /// to `Active`.
+    ///
+    /// Locked while any payroll run is prepared but not yet resolved (#253):
+    /// changing the company's lifecycle state mid-run is a policy-level
+    /// decision that should not be made while a run's outcome is still
+    /// pending. To stop payroll immediately in an emergency, use the pause
+    /// manager (always available) or cancel the specific pending run.
     pub fn set_company_state(e: Env, admin: Address, state: CompanyState) {
         let addrs: ContractAddresses = e
             .storage()
@@ -1699,6 +1722,7 @@ impl Payroll {
             panic!("Unauthorized");
         }
         admin.require_auth();
+        Self::require_no_active_payroll_run(&e);
         e.storage().persistent().set(&DataKey::CompanyState, &state);
         e.events().publish(
             (symbol_short!("payroll"), Symbol::new(&e, "state_changed")),
@@ -1778,7 +1802,7 @@ mod tests {
     use pause_manager::{PauseManager, PauseManagerClient};
     use proof_verifier::{ProofVerifier, VerificationKey};
     use salary_commitment::SalaryCommitmentContract;
-    use soroban_sdk::testutils::{Address as _, Events as _};
+    use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Env, IntoVal};
 
     fn mock_proof(env: &Env) -> BytesN<256> {
@@ -2861,7 +2885,7 @@ mod tests {
             PayrollRunState::Submitted
         );
 
-        payroll_client.cancel_payroll_run(&admin, &run_id);
+        payroll_client.cancel_payroll_run(&admin, &run_id, &Symbol::new(&env, "test"));
         assert_eq!(
             payroll_client.get_payroll_run_state(&run_id),
             PayrollRunState::Cancelled
@@ -2883,7 +2907,7 @@ mod tests {
             &test_nonce(&env, 151),
             &None,
         );
-        payroll_client.cancel_payroll_run(&admin, &run_id);
+        payroll_client.cancel_payroll_run(&admin, &run_id, &Symbol::new(&env, "test"));
 
         let result = payroll_client.try_transition_payroll_run_state(
             &admin,
@@ -2959,7 +2983,7 @@ mod tests {
         );
 
         // Cancel the pending run
-        payroll_client.cancel_payroll_run(&admin, &run_id);
+        payroll_client.cancel_payroll_run(&admin, &run_id, &Symbol::new(&env, "test"));
 
         // Verify it's no longer pending
         assert!(payroll_client.get_pending_run(&run_id).is_none());
@@ -3484,7 +3508,7 @@ mod tests {
     #[test]
     fn test_deposit_with_unique_id_succeeds() {
         let env = Env::default();
-        let (payroll_client, _admin, treasury, treasury_owner, _employee) =
+        let (payroll_client, _admin, treasury, _treasury_owner, _employee) =
             setup_simple_payroll(&env);
 
         let deposit_id = BytesN::from_array(&env, &[1u8; 32]);
@@ -3495,7 +3519,7 @@ mod tests {
     #[should_panic(expected = "Deposit already processed")]
     fn test_deposit_replay_with_same_id_rejected() {
         let env = Env::default();
-        let (payroll_client, _admin, treasury, treasury_owner, _employee) =
+        let (payroll_client, _admin, treasury, _treasury_owner, _employee) =
             setup_simple_payroll(&env);
 
         let deposit_id = BytesN::from_array(&env, &[2u8; 32]);
@@ -3506,7 +3530,7 @@ mod tests {
     #[test]
     fn test_deposit_distinct_ids_both_succeed() {
         let env = Env::default();
-        let (payroll_client, _admin, treasury, treasury_owner, _employee) =
+        let (payroll_client, _admin, treasury, _treasury_owner, _employee) =
             setup_simple_payroll(&env);
 
         let id1 = BytesN::from_array(&env, &[3u8; 32]);

--- a/docs/admin-config-locks.md
+++ b/docs/admin-config-locks.md
@@ -1,0 +1,88 @@
+# Admin Configuration Locks During Active Payroll Execution (#253)
+
+Admin configuration changes must not undermine a payroll run that is already
+in progress. This document covers two related, complementary gates in
+`contracts/payroll/src/lib.rs`:
+
+1. **Configuration lock** — while a payroll run is prepared but not yet
+   resolved, specific admin configuration changes are rejected.
+2. **Company lifecycle state gate** — the company's admin-set lifecycle
+   state (`CompanyState`, issue #147) determines whether *new* payroll runs
+   may start at all.
+
+## 1. What counts as "active payroll execution"
+
+A payroll run becomes active the moment `prepare_payroll_run` reserves its
+nonce and stores a `PendingPayrollRun` (canonical state `submitted`). It
+stays active until it is explicitly resolved via `cancel_payroll_run`
+(canonical state `cancelled`). The contract tracks how many runs are
+currently active in `DataKey::PendingRunCount`; `has_active_payroll_run()`
+exposes this as a boolean for clients and dashboards.
+
+Multiple runs can be active at once. The configuration lock stays engaged
+until **every** active run has been cancelled — cancelling one of several
+does not release it.
+
+## 2. Locked entrypoints
+
+While `has_active_payroll_run()` is `true`, these calls panic with
+`"Configuration is locked: a payroll run is currently in progress. Cancel
+all pending runs before changing this setting"`:
+
+| Entrypoint | Why it's unsafe mid-run |
+| --- | --- |
+| `accept_admin_rotation` | Handing off administration mid-run could let a party the run was not authorised under later act on it. |
+| `accept_treasury_rotation` | The treasury owner can request deposits and emergency withdrawals; rotating it mid-run could let a new party move funds while the run is pending. |
+| `set_asset_allowed` | Changing the payout asset allowlist mid-run could redirect or invalidate a run already validated against the previous allowlist. |
+| `set_company_state` | Changing the company's lifecycle state is a policy-level decision that should not be made while a run's outcome is still pending. |
+
+## 3. Deliberately left unlocked (escape hatches)
+
+| Entrypoint | Why it stays available |
+| --- | --- |
+| `propose_admin_rotation` / `propose_treasury_rotation` | Proposing is inert — nothing changes until the *accept* step, which is locked. |
+| `cancel_admin_rotation` / `cancel_treasury_rotation` | Cancelling a proposal only reverts to the status quo. |
+| `set_pause_manager` | Pausing is the system-wide emergency stop and must always remain reachable, including while other config is locked. |
+| `cancel_payroll_run` | This is the mechanism that *releases* the lock — it must never be blocked by the lock it clears. It also deliberately bypasses the pause check for the same reason (see its doc comment). |
+| `update_reconciliation_status` | Resolving an already-executed run's outcome must remain available regardless of other pending runs. |
+
+## 4. Company lifecycle state gate (issue #147)
+
+`CompanyState` (`Active` / `Paused` / `Archived` / `Incomplete`, default
+`Active` when never set) now gates whether a *new* run may start:
+`prepare_payroll_run` and `batch_process_payroll` both call
+`require_company_active` before any other validation, auth check, balance
+read, or transfer. Non-`Active` states panic with a state-specific message,
+e.g. `"Company is paused; payroll execution is not permitted"`.
+
+`set_company_state` is itself one of the locked entrypoints above, so an
+admin cannot pause/archive the company and simultaneously leave an
+in-flight run stranded in an ambiguous state — they must resolve (cancel)
+pending runs first, or use the always-available pause manager for an
+immediate stop.
+
+## 5. Errors and client guidance
+
+See the [Company Setup and Administration](./errors.md#company-setup-and-administration)
+table in `docs/errors.md` for the standard retry/recovery classification.
+Both gates fail with plain `panic!` messages (non-retryable until the
+underlying condition changes — cancel pending runs, or wait for the company
+state to be restored to `Active`); neither includes salary amounts,
+employee identities, or other private payroll values, so panic messages and
+the `has_active_payroll_run()` / `get_company_state()` read-only views are
+safe to surface directly in logs, dashboards, and error toasts.
+
+## 6. Tests
+
+- `tests/admin/` (`admin_config_lock_tests`) — configuration lock coverage:
+  each locked entrypoint rejected while a run is pending and accepted once
+  resolved, the multi-run "lock persists until all runs resolved" edge
+  case, and the escape-hatch entrypoints that remain available.
+- `tests/state/` (`company_state_gate_tests`) — company lifecycle state gate
+  coverage: default-`Active` backward compatibility, rejection under each
+  non-`Active` state, and the pause/resume round trip.
+
+```bash
+cargo test -p admin_config_lock_tests
+cargo test -p company_state_gate_tests
+```

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -23,6 +23,8 @@ where the contract exposes `Result<_, Error>`.
 | `payroll_registry.*` | `"Company not found"` | Unknown `company_id` or stale dashboard cache. | Retryable after state refresh | Refresh registry state and validate the company ID before resubmitting. |
 | Rotation entrypoints | `"Unauthorized: caller is not the company admin"` or host `authorized` failure | Wrong signer or wrong `current_admin` argument. | Non-retryable until signer changes | Prompt the registered admin to sign or fetch current company metadata. |
 | Rotation entrypoints | Pending rotation already exists / no pending rotation | The UI attempted a duplicate, stale, or out-of-order rotation step. | Retryable after refresh | Refresh pending rotation state and render the correct next action. |
+| `payroll.accept_admin_rotation`, `accept_treasury_rotation`, `set_asset_allowed`, `set_company_state` | `"Configuration is locked: a payroll run is currently in progress..."` | A payroll run is prepared (`prepare_payroll_run`) but not yet resolved. | Retryable after the run resolves | Cancel the pending run(s) via `cancel_payroll_run`, or wait for resolution, then retry. See [Admin Configuration Locks](./admin-config-locks.md). |
+| `payroll.prepare_payroll_run`, `batch_process_payroll` | `"Company is paused/archived/setup is incomplete; payroll execution is not permitted"` | The company's `CompanyState` is not `Active`. | Retryable once state returns to `Active` | Ask the admin to call `set_company_state(Active)`, then retry. See [Admin Configuration Locks](./admin-config-locks.md). |
 
 ## Employee Onboarding and Lifecycle
 

--- a/tests/access-control/unauthorized_actions.rs
+++ b/tests/access-control/unauthorized_actions.rs
@@ -242,7 +242,7 @@ fn test_unauthorized_cancel_payroll_run_fails() {
     );
 
     // Attempt to cancel as unauthorized user
-    payroll_client.cancel_payroll_run(&unauthorized_user, &run_id);
+    payroll_client.cancel_payroll_run(&unauthorized_user, &run_id, &Symbol::new(&env, "test"));
 }
 
 /// Test that unauthorized users cannot commit draft hashes.

--- a/tests/admin/Cargo.toml
+++ b/tests/admin/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "admin_config_lock_tests"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["lib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+payroll = { path = "../../contracts/payroll" }
+proof_verifier = { path = "../../contracts/proof_verifier" }
+salary_commitment = { path = "../../contracts/salary_commitment" }
+token = { path = "../../contracts/token" }
+pause_manager = { path = "../../contracts/pause_manager", features = ["contract"] }

--- a/tests/admin/src/lib.rs
+++ b/tests/admin/src/lib.rs
@@ -1,0 +1,333 @@
+//! # Admin Configuration Lock Tests (issue #253)
+//!
+//! Verifies that unsafe admin configuration changes are rejected while a
+//! payroll run is prepared but not yet resolved, and that they become
+//! available again once every pending run has been cancelled.
+//!
+//! Locked while a run is active: `accept_admin_rotation`,
+//! `accept_treasury_rotation`, `set_asset_allowed`, `set_company_state`.
+//!
+//! Deliberately left unlocked (escape hatches / inert steps):
+//! `propose_admin_rotation`, `cancel_admin_rotation`, `set_pause_manager`,
+//! `cancel_payroll_run` itself.
+//!
+//! ## How to run
+//!
+//! ```bash
+//! cargo test -p admin_config_lock_tests
+//! ```
+
+#[cfg(test)]
+mod tests {
+    use payroll::{CompanyState, Payroll, PayrollClient};
+    use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
+    use salary_commitment::{SalaryCommitmentContract, SalaryCommitmentContractClient};
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+    use token::{Token, TokenClient};
+
+    fn mock_vk(env: &Env) -> VerificationKey {
+        VerificationKey {
+            alpha: BytesN::from_array(env, &[0u8; 64]),
+            beta: BytesN::from_array(env, &[0u8; 128]),
+            gamma: BytesN::from_array(env, &[0u8; 128]),
+            delta: BytesN::from_array(env, &[0u8; 128]),
+            ic: Vec::from_array(
+                env,
+                [
+                    BytesN::from_array(env, &[0u8; 64]),
+                    BytesN::from_array(env, &[0u8; 64]),
+                    BytesN::from_array(env, &[0u8; 64]),
+                    BytesN::from_array(env, &[0u8; 64]),
+                ],
+            ),
+        }
+    }
+
+    fn mock_proof(env: &Env) -> BytesN<256> {
+        BytesN::from_array(env, &[0u8; 256])
+    }
+
+    fn test_nonce(env: &Env, seed: u8) -> BytesN<32> {
+        let mut arr = [0u8; 32];
+        arr[0] = seed;
+        BytesN::from_array(env, &arr)
+    }
+
+    /// Sets up a fully wired payroll contract with one registered employee.
+    /// Returns (payroll_client, admin, treasury, treasury_owner, employee).
+    fn setup(env: &Env) -> (PayrollClient<'_>, Address, Address, Address, Address) {
+        env.mock_all_auths();
+
+        let verifier_id = env.register_contract(None, ProofVerifier);
+        let verifier_client = ProofVerifierClient::new(env, &verifier_id);
+        let verifier_admin = Address::generate(env);
+        verifier_client.init_verifier_admin(&verifier_admin);
+        verifier_client.initialize_verifier(&mock_vk(env));
+
+        let commitment_id = env.register_contract(None, SalaryCommitmentContract);
+        let commitment_client = SalaryCommitmentContractClient::new(env, &commitment_id);
+        let commitment_admin = Address::generate(env);
+        commitment_client.init_commitment_admin(&commitment_admin);
+
+        let token_id = env.register_contract(None, Token);
+        let token_client = TokenClient::new(env, &token_id);
+
+        let payroll_id = env.register_contract(None, Payroll);
+        let payroll_client = PayrollClient::new(env, &payroll_id);
+
+        let treasury = Address::generate(env);
+        let admin = Address::generate(env);
+        let treasury_owner = Address::generate(env);
+        token_client.mint(&treasury, &1_000_000i128);
+        payroll_client.initialize(
+            &admin,
+            &token_id,
+            &verifier_id,
+            &commitment_id,
+            &treasury,
+            &treasury_owner,
+        );
+
+        commitment_client.set_payroll_operator(&payroll_id);
+
+        let employee = Address::generate(env);
+        commitment_client.store_commitment(&employee, &BytesN::from_array(env, &[0u8; 32]));
+
+        (payroll_client, admin, treasury, treasury_owner, employee)
+    }
+
+    fn prepare_a_run(
+        env: &Env,
+        payroll_client: &PayrollClient,
+        employee: &Address,
+        seed: u8,
+    ) -> u64 {
+        let mut proofs = Vec::new(env);
+        proofs.push_back(mock_proof(env));
+        let mut amounts = Vec::new(env);
+        amounts.push_back(1000i128);
+        let mut employees = Vec::new(env);
+        employees.push_back(employee.clone());
+
+        payroll_client.prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000i128,
+            &test_nonce(env, seed),
+            &None,
+        )
+    }
+
+    // ── has_active_payroll_run reflects pending state ─────────────────────────
+
+    #[test]
+    fn test_has_active_payroll_run_toggles_with_prepare_and_cancel() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        assert!(!payroll_client.has_active_payroll_run());
+
+        let run_id = prepare_a_run(&env, &payroll_client, &employee, 1);
+        assert!(payroll_client.has_active_payroll_run());
+
+        payroll_client.cancel_payroll_run(&admin, &run_id, &Symbol::new(&env, "test"));
+        assert!(!payroll_client.has_active_payroll_run());
+    }
+
+    #[test]
+    fn test_config_lock_persists_until_all_pending_runs_resolved() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        let run_a = prepare_a_run(&env, &payroll_client, &employee, 1);
+        let run_b = prepare_a_run(&env, &payroll_client, &employee, 2);
+        assert!(payroll_client.has_active_payroll_run());
+
+        // Resolving only one of two pending runs must keep the lock engaged.
+        payroll_client.cancel_payroll_run(&admin, &run_a, &Symbol::new(&env, "test"));
+        assert!(payroll_client.has_active_payroll_run());
+
+        let new_asset = Address::generate(&env);
+        let result = payroll_client.try_set_asset_allowed(&new_asset, &true);
+        assert!(result.is_err(), "lock must still be engaged");
+
+        // Resolving the second (last) pending run releases the lock.
+        payroll_client.cancel_payroll_run(&admin, &run_b, &Symbol::new(&env, "test"));
+        assert!(!payroll_client.has_active_payroll_run());
+        payroll_client.set_asset_allowed(&new_asset, &true);
+    }
+
+    // ── accept_admin_rotation ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_accept_admin_rotation_blocked_while_run_pending() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        let new_admin = Address::generate(&env);
+        payroll_client.propose_admin_rotation(&admin, &new_admin);
+
+        prepare_a_run(&env, &payroll_client, &employee, 1);
+
+        let result = payroll_client.try_accept_admin_rotation(&new_admin);
+        assert!(
+            result.is_err(),
+            "accept must be locked while a run is pending"
+        );
+    }
+
+    #[test]
+    fn test_accept_admin_rotation_succeeds_after_run_cancelled() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        let new_admin = Address::generate(&env);
+        payroll_client.propose_admin_rotation(&admin, &new_admin);
+
+        let run_id = prepare_a_run(&env, &payroll_client, &employee, 1);
+        payroll_client.cancel_payroll_run(&admin, &run_id, &Symbol::new(&env, "test"));
+
+        payroll_client.accept_admin_rotation(&new_admin);
+        assert!(payroll_client.get_pending_admin_rotation().is_none());
+    }
+
+    /// Proposing a rotation is inert (nothing mutates until accepted), so it
+    /// must remain available even while a run is pending.
+    #[test]
+    fn test_propose_admin_rotation_not_blocked_by_active_run() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        prepare_a_run(&env, &payroll_client, &employee, 1);
+
+        let new_admin = Address::generate(&env);
+        payroll_client.propose_admin_rotation(&admin, &new_admin);
+        assert!(payroll_client.get_pending_admin_rotation().is_some());
+    }
+
+    // ── accept_treasury_rotation ───────────────────────────────────────────────
+
+    #[test]
+    fn test_accept_treasury_rotation_blocked_while_run_pending() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, treasury_owner, employee) = setup(&env);
+
+        let new_owner = Address::generate(&env);
+        payroll_client.propose_treasury_rotation(&treasury_owner, &new_owner);
+
+        prepare_a_run(&env, &payroll_client, &employee, 1);
+
+        let result = payroll_client.try_accept_treasury_rotation(&new_owner);
+        assert!(
+            result.is_err(),
+            "accept must be locked while a run is pending"
+        );
+    }
+
+    #[test]
+    fn test_accept_treasury_rotation_succeeds_after_run_cancelled() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, treasury_owner, employee) = setup(&env);
+
+        let new_owner = Address::generate(&env);
+        payroll_client.propose_treasury_rotation(&treasury_owner, &new_owner);
+
+        let run_id = prepare_a_run(&env, &payroll_client, &employee, 1);
+        payroll_client.cancel_payroll_run(&admin, &run_id, &Symbol::new(&env, "test"));
+
+        payroll_client.accept_treasury_rotation(&new_owner);
+        assert!(payroll_client.get_pending_treasury_rotation().is_none());
+    }
+
+    // ── set_asset_allowed ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_asset_allowed_blocked_while_run_pending() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        prepare_a_run(&env, &payroll_client, &employee, 1);
+
+        let new_asset = Address::generate(&env);
+        let result = payroll_client.try_set_asset_allowed(&new_asset, &true);
+        assert!(
+            result.is_err(),
+            "asset allowlist changes must be locked while a run is pending"
+        );
+    }
+
+    #[test]
+    fn test_set_asset_allowed_works_with_no_pending_runs() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, _employee) = setup(&env);
+
+        let new_asset = Address::generate(&env);
+        payroll_client.set_asset_allowed(&new_asset, &true);
+        assert!(payroll_client.is_asset_allowed(&new_asset));
+    }
+
+    // ── set_company_state ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_company_state_blocked_while_run_pending() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        prepare_a_run(&env, &payroll_client, &employee, 1);
+
+        let result = payroll_client.try_set_company_state(&admin, &CompanyState::Paused);
+        assert!(
+            result.is_err(),
+            "company state changes must be locked while a run is pending"
+        );
+    }
+
+    #[test]
+    fn test_set_company_state_succeeds_after_run_cancelled() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        let run_id = prepare_a_run(&env, &payroll_client, &employee, 1);
+        payroll_client.cancel_payroll_run(&admin, &run_id, &Symbol::new(&env, "test"));
+
+        payroll_client.set_company_state(&admin, &CompanyState::Paused);
+        assert_eq!(payroll_client.get_company_state(), CompanyState::Paused);
+    }
+
+    // ── Escape hatches remain available during an active run ─────────────────
+
+    /// Pausing the whole system must always remain available as an emergency
+    /// stop, even while a run is pending and other config is locked.
+    #[test]
+    fn test_set_pause_manager_not_blocked_by_active_run() {
+        let env = Env::default();
+        let (payroll_client, _admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        prepare_a_run(&env, &payroll_client, &employee, 1);
+
+        let pm_id = env.register_contract(None, pause_manager::PauseManager);
+        let pm_client = pause_manager::PauseManagerClient::new(&env, &pm_id);
+        let operator = Address::generate(&env);
+        pm_client.initialize(&operator);
+
+        // Must not panic.
+        payroll_client.set_pause_manager(&pm_id);
+    }
+
+    /// Cancelling a pending run is the mechanism that releases the lock, so
+    /// it must never be blocked by the lock itself.
+    #[test]
+    fn test_cancel_payroll_run_always_available_while_locked() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) = setup(&env);
+
+        let run_a = prepare_a_run(&env, &payroll_client, &employee, 1);
+        let run_b = prepare_a_run(&env, &payroll_client, &employee, 2);
+
+        payroll_client.cancel_payroll_run(&admin, &run_a, &Symbol::new(&env, "test"));
+        payroll_client.cancel_payroll_run(&admin, &run_b, &Symbol::new(&env, "test"));
+        assert!(!payroll_client.has_active_payroll_run());
+    }
+}

--- a/tests/state/Cargo.toml
+++ b/tests/state/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "company_state_gate_tests"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["lib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+payroll = { path = "../../contracts/payroll" }
+proof_verifier = { path = "../../contracts/proof_verifier" }
+salary_commitment = { path = "../../contracts/salary_commitment" }
+token = { path = "../../contracts/token" }

--- a/tests/state/src/lib.rs
+++ b/tests/state/src/lib.rs
@@ -1,0 +1,252 @@
+//! # Company Lifecycle State Execution Gate Tests (issue #147 / #253)
+//!
+//! `CompanyState` (`Active` / `Paused` / `Archived` / `Incomplete`) is meant
+//! to gate whether a company's payroll can execute at all: per
+//! `docs/architecture/company-lifecycle-states-106.md`, "payroll execution
+//! is only permitted when the state is `Active`". These tests cover that
+//! gate as wired into `prepare_payroll_run` and `batch_process_payroll`, and
+//! confirm the default (no state ever set) preserves existing Active
+//! behavior for deployments that predate this field.
+//!
+//! ## How to run
+//!
+//! ```bash
+//! cargo test -p company_state_gate_tests
+//! ```
+
+#[cfg(test)]
+mod tests {
+    use payroll::{CompanyState, Payroll, PayrollClient};
+    use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
+    use salary_commitment::{SalaryCommitmentContract, SalaryCommitmentContractClient};
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, BytesN, Env, Vec};
+    use token::{Token, TokenClient};
+
+    fn mock_vk(env: &Env) -> VerificationKey {
+        VerificationKey {
+            alpha: BytesN::from_array(env, &[0u8; 64]),
+            beta: BytesN::from_array(env, &[0u8; 128]),
+            gamma: BytesN::from_array(env, &[0u8; 128]),
+            delta: BytesN::from_array(env, &[0u8; 128]),
+            ic: Vec::from_array(
+                env,
+                [
+                    BytesN::from_array(env, &[0u8; 64]),
+                    BytesN::from_array(env, &[0u8; 64]),
+                    BytesN::from_array(env, &[0u8; 64]),
+                    BytesN::from_array(env, &[0u8; 64]),
+                ],
+            ),
+        }
+    }
+
+    fn mock_proof(env: &Env) -> BytesN<256> {
+        BytesN::from_array(env, &[0u8; 256])
+    }
+
+    fn test_nonce(env: &Env, seed: u8) -> BytesN<32> {
+        let mut arr = [0u8; 32];
+        arr[0] = seed;
+        BytesN::from_array(env, &arr)
+    }
+
+    /// Sets up a fully wired payroll contract with one registered employee.
+    /// Returns (payroll_client, admin, employee).
+    fn setup(env: &Env) -> (PayrollClient<'_>, Address, Address) {
+        env.mock_all_auths();
+
+        let verifier_id = env.register_contract(None, ProofVerifier);
+        let verifier_client = ProofVerifierClient::new(env, &verifier_id);
+        let verifier_admin = Address::generate(env);
+        verifier_client.init_verifier_admin(&verifier_admin);
+        verifier_client.initialize_verifier(&mock_vk(env));
+
+        let commitment_id = env.register_contract(None, SalaryCommitmentContract);
+        let commitment_client = SalaryCommitmentContractClient::new(env, &commitment_id);
+        let commitment_admin = Address::generate(env);
+        commitment_client.init_commitment_admin(&commitment_admin);
+
+        let token_id = env.register_contract(None, Token);
+        let token_client = TokenClient::new(env, &token_id);
+
+        let payroll_id = env.register_contract(None, Payroll);
+        let payroll_client = PayrollClient::new(env, &payroll_id);
+
+        let treasury = Address::generate(env);
+        let admin = Address::generate(env);
+        let treasury_owner = Address::generate(env);
+        token_client.mint(&treasury, &1_000_000i128);
+        payroll_client.initialize(
+            &admin,
+            &token_id,
+            &verifier_id,
+            &commitment_id,
+            &treasury,
+            &treasury_owner,
+        );
+
+        commitment_client.set_payroll_operator(&payroll_id);
+
+        let employee = Address::generate(env);
+        commitment_client.store_commitment(&employee, &BytesN::from_array(env, &[0u8; 32]));
+
+        (payroll_client, admin, employee)
+    }
+
+    fn single_batch(env: &Env, employee: &Address) -> (Vec<BytesN<256>>, Vec<i128>, Vec<Address>) {
+        let mut proofs = Vec::new(env);
+        proofs.push_back(mock_proof(env));
+        let mut amounts = Vec::new(env);
+        amounts.push_back(1000i128);
+        let mut employees = Vec::new(env);
+        employees.push_back(employee.clone());
+        (proofs, amounts, employees)
+    }
+
+    #[test]
+    fn test_default_company_state_is_active() {
+        let env = Env::default();
+        let (payroll_client, _admin, _employee) = setup(&env);
+
+        assert_eq!(payroll_client.get_company_state(), CompanyState::Active);
+    }
+
+    // ── prepare_payroll_run gated by company state ────────────────────────────
+
+    #[test]
+    fn test_prepare_payroll_run_succeeds_by_default() {
+        let env = Env::default();
+        let (payroll_client, _admin, employee) = setup(&env);
+
+        let (proofs, amounts, employees) = single_batch(&env, &employee);
+        let run_id = payroll_client.prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000i128,
+            &test_nonce(&env, 1),
+            &None,
+        );
+        assert!(run_id > 0);
+    }
+
+    #[test]
+    fn test_prepare_payroll_run_rejected_when_paused() {
+        let env = Env::default();
+        let (payroll_client, admin, employee) = setup(&env);
+        payroll_client.set_company_state(&admin, &CompanyState::Paused);
+
+        let (proofs, amounts, employees) = single_batch(&env, &employee);
+        let result = payroll_client.try_prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000i128,
+            &test_nonce(&env, 2),
+            &None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_prepare_payroll_run_rejected_when_archived() {
+        let env = Env::default();
+        let (payroll_client, admin, employee) = setup(&env);
+        payroll_client.set_company_state(&admin, &CompanyState::Archived);
+
+        let (proofs, amounts, employees) = single_batch(&env, &employee);
+        let result = payroll_client.try_prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000i128,
+            &test_nonce(&env, 3),
+            &None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_prepare_payroll_run_rejected_when_incomplete() {
+        let env = Env::default();
+        let (payroll_client, admin, employee) = setup(&env);
+        payroll_client.set_company_state(&admin, &CompanyState::Incomplete);
+
+        let (proofs, amounts, employees) = single_batch(&env, &employee);
+        let result = payroll_client.try_prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000i128,
+            &test_nonce(&env, 4),
+            &None,
+        );
+        assert!(result.is_err());
+    }
+
+    // ── batch_process_payroll gated by company state ──────────────────────────
+
+    #[test]
+    fn test_batch_process_payroll_rejected_when_paused() {
+        let env = Env::default();
+        let (payroll_client, admin, employee) = setup(&env);
+        payroll_client.set_company_state(&admin, &CompanyState::Paused);
+
+        let (proofs, amounts, employees) = single_batch(&env, &employee);
+        let result = payroll_client.try_batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000i128,
+            &test_nonce(&env, 5),
+            &None,
+        );
+        assert!(result.is_err());
+    }
+
+    /// Round trip: pausing blocks execution, and restoring Active resumes it
+    /// — the gate must not be a one-way trip.
+    #[test]
+    fn test_batch_process_payroll_resumes_after_returning_to_active() {
+        let env = Env::default();
+        let (payroll_client, admin, employee) = setup(&env);
+        payroll_client.set_company_state(&admin, &CompanyState::Paused);
+
+        let (proofs, amounts, employees) = single_batch(&env, &employee);
+        let blocked = payroll_client.try_batch_process_payroll(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000i128,
+            &test_nonce(&env, 6),
+            &None,
+        );
+        assert!(blocked.is_err());
+
+        payroll_client.set_company_state(&admin, &CompanyState::Active);
+
+        let (proofs2, amounts2, employees2) = single_batch(&env, &employee);
+        let run_id = payroll_client.batch_process_payroll(
+            &proofs2,
+            &amounts2,
+            &employees2,
+            &1000i128,
+            &test_nonce(&env, 7),
+            &None,
+        );
+        assert!(run_id > 0);
+    }
+
+    // ── Access control ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_non_admin_cannot_set_company_state() {
+        let env = Env::default();
+        let (payroll_client, _admin, _employee) = setup(&env);
+
+        let attacker = Address::generate(&env);
+        let result = payroll_client.try_set_company_state(&attacker, &CompanyState::Archived);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #279.

Adds configuration locks that reject unsafe admin configuration changes while a payroll run is prepared but not yet resolved, per the issue's "Admin configuration changes should not undermine payroll runs already in progress."

- A payroll run is "active" from `prepare_payroll_run` (canonical state `submitted`) until it's resolved via `cancel_payroll_run` (`cancelled`). `contracts/payroll` now tracks how many runs are currently active and exposes it via `has_active_payroll_run()`.
- **Locked** while any run is active: `accept_admin_rotation`, `accept_treasury_rotation`, `set_asset_allowed`, `set_company_state` — each now panics with `"Configuration is locked: a payroll run is currently in progress. Cancel all pending runs before changing this setting"`.
- **Left unlocked on purpose** (escape hatches, documented in `docs/admin-config-locks.md`): proposing/cancelling a rotation (inert until accepted), `set_pause_manager` (must always remain reachable as an emergency stop), and `cancel_payroll_run` itself (the mechanism that releases the lock).
- As the direct counterpart to this lock, wired the existing-but-never-called `require_company_active` gate (`CompanyState`, issue #147) into `prepare_payroll_run` and `batch_process_payroll` — it had full doc comments describing the intended behavior but was dead code with zero test coverage before this PR.

No private payroll values (amounts, employee identities) appear in the new panic messages or the `has_active_payroll_run()` read-only view — see "Privacy" section of `docs/admin-config-locks.md`.

## Pre-existing issues fixed along the way

While reviewing the codebase to find the right integration point, `cargo check -p payroll` didn't compile at all, which meant nothing here (or in the base repo) could be tested. Fixed the blockers, all unrelated to this feature but required to build/test anything:

- `pause_manager`'s hand-written client (`PauseManagerClient::get_pending_operator_rotation`) passed `()` instead of an empty `Vec<Val>` to `invoke_contract` — compile error.
- `contracts/payroll/src/lib.rs` had two conflicting `cancel_payroll_run` definitions (leftover merge damage — one mislabeled with a stale "finalize" doc comment), plus a missing `symbol_short` import and a missing `AllowedAsset` enum variant used by `set_asset_allowed`/`is_asset_allowed`. Reconciled to the single, better-designed 4-arg (`reason: Symbol`) version and updated the ~4 call sites still using the old 2-arg signature (including in `tests/access-control/unauthorized_actions.rs`).
- A few stray clippy warnings (`clone_on_copy`, unused import/variables) in the same file that block the workspace `-D warnings` clippy gate.

Flagging but **not** fixing (out of scope for this PR): `tests/migrations` (`migration_tests`) currently fails to compile (`AuditModuleClient::initialize` doesn't exist), so `cargo test --workspace` / `cargo clippy --workspace` are red on `main` independent of this change. Also, `tests/access-control/unauthorized_actions.rs` has no `Cargo.toml` and isn't a workspace member, so it's silently never run by CI today.

## Test plan

- [x] `cargo test -p payroll` — 85 passed (existing suite, unbroken)
- [x] `cargo test -p pause_manager` — 16 passed (existing suite, unbroken)
- [x] `cargo test -p admin_config_lock_tests` — 13 new tests: each locked entrypoint rejected while a run is pending / allowed once resolved, the multi-run "lock persists until all runs resolved" edge case, and the escape hatches (`propose_admin_rotation`, `set_pause_manager`, `cancel_payroll_run`) remaining available
- [x] `cargo test -p company_state_gate_tests` — 8 new tests: default-Active backward compatibility, rejection under each non-Active `CompanyState`, the pause/resume round trip, and the admin-only auth boundary
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p payroll -p pause_manager -p admin_config_lock_tests -p company_state_gate_tests --all-targets -- -D warnings` — clean