### PR TITLE
Fix syntax error in auto-merge-dev-prs.yml github-script

### DIFF
--- a/.github/workflows/auto-merge-dev-prs.yml
+++ b/.github/workflows/auto-merge-dev-prs.yml
@@ -103,13 +103,13 @@ jobs:
 
             let current = await waitForMergeability();
             if (current.mergeable === false || current.mergeable_state === "dirty") {
-              await comment(`${mention} this PR has merge conflicts with `dev`. Please resolve the conflicts, push the fix, and the automation will recheck immediately.`);
+              await comment(`${mention} this PR has merge conflicts with \`dev\`. Please resolve the conflicts, push the fix, and the automation will recheck immediately.`);
               return;
             }
 
             const ci = await waitForCi();
             if (ci.total === 0) {
-              await comment(`${mention} no CI result was found for this PR yet. Please confirm the CI workflow ran for `dev` and push another update if needed.`);
+              await comment(`${mention} no CI result was found for this PR yet. Please confirm the CI workflow ran for \`dev\` and push another update if needed.`);
               return;
             }
             if (ci.pending.length > 0) {
@@ -123,7 +123,7 @@ jobs:
 
             current = await waitForMergeability();
             if (current.mergeable === false || current.mergeable_state === "dirty") {
-              await comment(`${mention} CI passed, but this PR now has merge conflicts with `dev`. Please resolve the conflicts and push again.`);
+              await comment(`${mention} CI passed, but this PR now has merge conflicts with \`dev\`. Please resolve the conflicts and push again.`);
               return;
             }
 


### PR DESCRIPTION
## Summary

Not tied to a specific issue — found while working on #279 and #284, both of which were blocked by this.

The `handle-dev-pr` job (`.github/workflows/auto-merge-dev-prs.yml`) fails on **every** PR targeting `dev`, regardless of that PR's own content or CI status:

```
SyntaxError: missing ) after argument list
```

Three of the `comment(...)` calls embed literal backticks around `dev` inside an outer template literal:

```js
await comment(`${mention} this PR has merge conflicts with `dev`. Please resolve...`);
```

The inner `` `dev` `` closes the outer template literal early, leaving a dangling backtick that breaks the argument list. Since this is inside a single `actions/github-script` step, the whole script fails to parse before any of its logic (CI check, mergeability check, auto-merge) ever runs — so `handle-dev-pr` shows as a hard failure on every PR, independent of whether the PR's actual code/CI is fine.

## Fix

Escaped the inner backticks (`` \`dev\` ``) in all three call sites so they render as literal backtick-quoted text in the posted PR comment instead of terminating the template literal early. No behavioral change to the automation logic — same three messages, now they actually get posted instead of crashing first.

## Verification

Extracted the `script:` block scalar and checked it in isolation:

```bash
node --check extracted_script.js   # exit 0, no syntax errors
```

(Can't fully exercise `waitForCi`/merge logic locally since it depends on the GitHub Actions `github`/`context` objects, but the fix is a pure syntax correction — no logic touched.)