### PR TITLE
Add payroll period overlap tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ name = "payroll"
 version = "0.1.0"
 dependencies = [
  "pause_manager",
+ "payroll_events",
  "payroll_registry",
  "proof_verifier",
  "salary_commitment",

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -814,6 +814,103 @@ mod tests {
     }
 
     #[test]
+    fn test_overlapping_active_period_creation_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, PaymentExecutor);
+        let client = PaymentExecutorClient::new(&env, &contract_id);
+
+        let addresses = setup_addresses(&env);
+        client.initialize(&addresses);
+
+        let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let company_id = registry_client.register_company(&admin, &treasury);
+
+        let first_period = client.create_period(&company_id);
+        assert!(!first_period.closed);
+
+        let overlapping_period = client.try_create_period(&company_id);
+        assert_eq!(
+            overlapping_period.unwrap_err().unwrap(),
+            PaymentError::PeriodAlreadyExists,
+            "a company cannot open period 2 while period 1 is still active"
+        );
+
+        let still_open = client.get_period(&company_id, &1).unwrap();
+        assert!(
+            !still_open.closed,
+            "failed overlap attempt must not close period 1"
+        );
+        assert!(
+            client.get_period(&company_id, &2).is_none(),
+            "failed overlap attempt must not create a second active period"
+        );
+    }
+
+    #[test]
+    fn test_new_period_succeeds_after_prior_period_is_closed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, PaymentExecutor);
+        let client = PaymentExecutorClient::new(&env, &contract_id);
+
+        let addresses = setup_addresses(&env);
+        client.initialize(&addresses);
+
+        let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let company_id = registry_client.register_company(&admin, &treasury);
+
+        let first_period = client.create_period(&company_id);
+        assert_eq!(first_period.period_id, 1);
+
+        let closed_period = client.close_period(&company_id, &1);
+        assert!(closed_period.closed);
+
+        let second_period = client.create_period(&company_id);
+        assert_eq!(second_period.period_id, 2);
+        assert_eq!(second_period.company_id, company_id);
+        assert!(!second_period.closed);
+        assert_eq!(second_period.end_ledger, 0);
+    }
+
+    #[test]
+    fn test_period_overlap_is_scoped_per_company() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, PaymentExecutor);
+        let client = PaymentExecutorClient::new(&env, &contract_id);
+
+        let addresses = setup_addresses(&env);
+        client.initialize(&addresses);
+
+        let registry_client = PayrollRegistryClient::new(&env, &addresses.registry);
+        let admin_a = Address::generate(&env);
+        let treasury_a = Address::generate(&env);
+        let admin_b = Address::generate(&env);
+        let treasury_b = Address::generate(&env);
+        let company_a = registry_client.register_company(&admin_a, &treasury_a);
+        let company_b = registry_client.register_company(&admin_b, &treasury_b);
+
+        let company_a_period = client.create_period(&company_a);
+        assert_eq!(company_a_period.period_id, 1);
+
+        let company_b_period = client.create_period(&company_b);
+        assert_eq!(company_b_period.period_id, 1);
+        assert_eq!(company_b_period.company_id, company_b);
+
+        let company_a_overlap = client.try_create_period(&company_a);
+        assert_eq!(
+            company_a_overlap.unwrap_err().unwrap(),
+            PaymentError::PeriodAlreadyExists,
+            "overlap rejection must apply only within the same company"
+        );
+    }
+
+    #[test]
     fn test_close_period() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
## Summary

Ensure the `payment_executor` contract enforces that only one active payroll period exists per company, preventing overlapping periods that could cause reporting or settlement confusion.

Closes #269

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that changes existing behaviour)
* [ ] ZK circuit change (requires new trusted setup / ptau ceremony)
* [ ] Refactor (no functional changes)
* [ ] Documentation / comments only
* [ ] CI/CD or tooling change

## Description of Changes

* Added three unit tests in `contracts/payment_executor/src/lib.rs` covering payroll period lifecycle and active-period constraints.
* Added coverage to ensure overlapping active period creation is rejected.
* Added coverage to ensure a new period can be created after the previous period is closed.
* Added coverage to verify active-period enforcement is scoped independently per company.
* Tests exercise `create_period`, `try_create_period`, `close_period`, and `get_period` behavior and validate the expected lifecycle side effects.
* Updated `Cargo.lock` to reflect the `payroll_events` dependency in the workspace dependency graph.

---

## Checklist

### General

* [x] My code follows the project's Rust style guidelines (`cargo fmt --check` passes)
* [x] I have performed a self-review of my own code
* [ ] I have added comments for any non-obvious logic
* [ ] I have updated relevant documentation (`README.md`, `CONTRIBUTING.md`, inline docs)
* [x] My changes do not introduce new compiler warnings (`cargo clippy` passes)
* [x] I have added tests that cover my changes
* [ ] All existing tests pass locally (`cargo test`)

### Smart Contracts (if applicable)

* [ ] I have measured and documented gas / resource usage for new or changed entry-points

  * CPU instructions (before / after): N/A
  * Memory bytes (before / after): N/A
  * Ledger entries read/written (before / after): N/A
  * Estimated XLM fee (before / after): N/A
* [x] I have verified there are no storage layout regressions (state rent impact assessed)
* [x] I have checked for integer overflow / underflow and used checked arithmetic
* [x] Authorization checks (`require_auth`, `require_auth_for_args`) are correct and tested
* [x] No sensitive data (salaries, blinding factors, private keys) is emitted in events or exposed in storage

### ZK Circuits (if applicable)

* [ ] Circuit compiles without errors: `circom <circuit>.circom --r1cs --wasm --sym`
* [ ] Witness generation succeeds for test inputs
* [ ] Proof generation and verification pass end-to-end
* [ ] New trusted setup (phase 2 ptau) is required: **No**

  * If yes, link to the ceremony artifacts: N/A
* [ ] Constraint count change documented:

  * Before: N/A
  * After: N/A
* [ ] Verifier Solidity/Rust contract regenerated (if verifying key changed)

### Security

* [x] I have considered potential attack vectors relevant to this change

  * [x] Re-entrancy (not applicable on Soroban, but noted for audit completeness)
  * [ ] Front-running / MEV risks
  * [ ] Proof malleability (for ZK changes)
  * [x] Commitment binding / hiding properties preserved (for commitment changes)
* [x] No hardcoded secrets, keys, or sensitive configuration values in code
* [x] Dependencies added/updated have been reviewed for known vulnerabilities (`cargo audit`)

---

## Testing Evidence

Period-focused unit tests were run successfully:

```text
cargo test -p payment_executor --lib period

9 passed; 0 failed
```

The broader package test was also run:

```text
cargo test -p payment_executor period
```

The newly added library period tests passed. An unrelated existing integration test failed:

```text
test_period_payment_count_increments_per_payment
```

in `invariant_tests`. This failure occurred independently of the new period-overlap tests.

## Additional Notes

* No contract entry-points or storage layouts were changed; this PR adds test coverage for the existing payroll period lifecycle behavior.
* `Cargo.lock` was updated to reflect the `payroll_events` dependency in the workspace dependency graph.
* The existing integration-test failure should be investigated separately and does not appear to be caused by these changes.

