### PR TITLE
feat(tests): add payroll cancellation state cleanup and audit tests

### DIFF
--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -1095,7 +1095,7 @@ impl Payroll {
 
         // Remove the pending run from storage
         e.storage().persistent().remove(&pending_key);
-        Self::record_payroll_run_state(&e, run_id, PayrollRunState::Cancelled);
+        Self::record_payroll_run_state(&e, run_id, PayrollRunState::ReconciliationRequired);
 
         let run = PayrollRun {
             run_id,
@@ -3630,6 +3630,41 @@ mod tests {
         payroll_client.cancel_payroll_run_with_reason(&admin, &run_id, &reason);
 
         assert!(payroll_client.get_pending_run(&run_id).is_none());
+        assert_eq!(
+            payroll_client.get_payroll_run_state(&run_id),
+            PayrollRunState::Cancelled
+        );
+    }
+
+    #[test]
+    fn test_finalize_payroll_run_records_reconciliation_required_and_cleans_pending() {
+        let env = Env::default();
+        let (payroll_client, admin, _treasury, _treasury_owner, employee) =
+            setup_simple_payroll(&env);
+
+        let nonce = test_nonce(&env, 46);
+        let (proofs, amounts, employees) = single_payment_batch(&env, &employee, 1000);
+        let run_id =
+            payroll_client.prepare_payroll_run(&proofs, &amounts, &employees, &1000, &nonce, &None);
+
+        assert!(payroll_client.get_pending_run(&run_id).is_some());
+        assert_eq!(
+            payroll_client.get_payroll_run_state(&run_id),
+            PayrollRunState::Submitted
+        );
+
+        payroll_client.finalize_payroll_run(&admin, &run_id);
+
+        assert!(payroll_client.get_pending_run(&run_id).is_none());
+        assert_eq!(
+            payroll_client.get_payroll_run_state(&run_id),
+            PayrollRunState::ReconciliationRequired
+        );
+        let run = payroll_client.get_payroll_run(&run_id);
+        assert_eq!(
+            run.reconciliation_status,
+            ReconciliationStatus::Unreconciled
+        );
     }
 
     #[test]

--- a/docs/payroll-state-machine.md
+++ b/docs/payroll-state-machine.md
@@ -136,3 +136,15 @@ In addition to the run state machine, `RunDraftState` in `contracts/payroll/src/
 
 All draft state transitions emit events containing only `(draft_id, admin)` identifiers. Individual employee salary values, bank details, and salary commitments remain redacted and unexposed in state logs, telemetry, and contract state.
 
+---
+
+## Cancellation State Cleanup & Audit Preservation
+
+When an admin cancels a pending payroll run via `cancel_payroll_run_with_reason`:
+1. **Active Storage Cleanup**: The `PendingPayrollRun` record (`DataKey::PendingRun(run_id)`) is immediately removed from persistent storage to prevent execution race conditions and double-spending.
+2. **Audit State Preservation**: The canonical state `PayrollRunState::Cancelled` is permanently recorded in `DataKey::PayrollState(run_id)`. Reconcilers and auditors querying `get_payroll_run_state(run_id)` receive `Cancelled`, distinguishing an intentional cancellation from an invalid ID.
+3. **Replay Protection**: The `RunNonce` remains marked as spent in storage, preventing any replay of the exact same batch nonce.
+4. **Treasury Safety**: No token transfers or balance deductions occur; treasury balances remain completely untouched.
+5. **Emergency Escape Hatch**: Run cancellation does not require the contract to be unpaused, allowing admins to safely cancel problematic runs during an active incident pause.
+6. **Privacy Preserved**: The `run_cancelled` event publishes only `(run_id, reason)` topics/data, omitting all sensitive individual employee identifiers, amounts, or cryptographic secrets.
+

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -29,8 +29,15 @@ Tracks off-chain preparation and admin draft management prior to processing:
 - **Cancelled**: Stopped before execution via `cancel_run_draft` (terminal).
 - **Expired**: Marked stale/expired via `expire_run_draft` (terminal).
 
+## 3. Cancellation & State Cleanup Semantics
+
+- **Pending Run Cancellation**: Calling `cancel_payroll_run_with_reason` purges the transient `PendingRun` record from contract storage, records `PayrollRunState::Cancelled` in `PayrollState`, and keeps the batch nonce permanently consumed for audit trail integrity and replay prevention.
+- **Draft Cancellation**: Calling `cancel_run_draft` transitions the draft to terminal `Cancelled`, preserving historical amendment and creation metadata while blocking further modifications.
+- **Escape Hatch**: Run cancellation is explicitly allowed during emergency pause to empower admins to recover from invalid or compromised submissions.
+
 ## Privacy Compliance
 
 In accordance with system privacy requirements:
-- State transitions only record metadata (`draft_id`, `admin`, `total_amount` aggregate, `period_label`).
+- State transitions only record metadata (`draft_id`, `admin`, `total_amount` aggregate, `period_label`, `run_id`, `reason`).
 - Individual salary amounts, employee identifiers, and commitment seeds are **never** included in events, state variables, or logs.
+

--- a/tests/state/src/cancellation_state_cleanup_tests.rs
+++ b/tests/state/src/cancellation_state_cleanup_tests.rs
@@ -1,0 +1,632 @@
+#![cfg(test)]
+
+use pause_manager::{PauseManager, PauseManagerClient};
+use payroll::{Payroll, PayrollClient, PayrollRunState, ReconciliationStatus, RunDraftState};
+use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
+use salary_commitment::{SalaryCommitmentContract, SalaryCommitmentContractClient};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol, TryIntoVal, Vec};
+use token::{Token, TokenClient};
+
+fn mock_vk(env: &Env) -> VerificationKey {
+    VerificationKey {
+        alpha: BytesN::from_array(env, &[0u8; 64]),
+        beta: BytesN::from_array(env, &[0u8; 128]),
+        gamma: BytesN::from_array(env, &[0u8; 128]),
+        delta: BytesN::from_array(env, &[0u8; 128]),
+        ic: Vec::from_array(
+            env,
+            [
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+            ],
+        ),
+    }
+}
+
+fn mock_proof(env: &Env) -> BytesN<256> {
+    BytesN::from_array(env, &[1u8; 256])
+}
+
+fn test_nonce(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    bytes[31] = 0xAA;
+    BytesN::from_array(env, &bytes)
+}
+
+struct TestContext<'a> {
+    env: Env,
+    payroll_client: PayrollClient<'a>,
+    token_client: TokenClient<'a>,
+    pause_manager_client: PauseManagerClient<'a>,
+    admin: Address,
+    treasury: Address,
+    employee: Address,
+}
+
+fn setup_test_context() -> TestContext<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let verifier_id = env.register_contract(None, ProofVerifier);
+    let verifier_client = ProofVerifierClient::new(&env, &verifier_id);
+    let verifier_admin = Address::generate(&env);
+    verifier_client.init_verifier_admin(&verifier_admin);
+    verifier_client.initialize_verifier(&mock_vk(&env));
+
+    let commitment_id = env.register_contract(None, SalaryCommitmentContract);
+    let commitment_client = SalaryCommitmentContractClient::new(&env, &commitment_id);
+    let commitment_admin = Address::generate(&env);
+    commitment_client.init_commitment_admin(&commitment_admin);
+
+    let token_id = env.register_contract(None, Token);
+    let token_client = TokenClient::new(&env, &token_id);
+
+    let payroll_id = env.register_contract(None, Payroll);
+    let payroll_client = PayrollClient::new(&env, &payroll_id);
+
+    let treasury = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let treasury_owner = Address::generate(&env);
+    let operator = Address::generate(&env);
+
+    token_client.mint(&treasury, &10_000_000i128);
+
+    payroll_client.initialize(
+        &admin,
+        &token_id,
+        &verifier_id,
+        &commitment_id,
+        &treasury,
+        &treasury_owner,
+    );
+
+    commitment_client.set_payroll_operator(&payroll_id);
+
+    let pm_id = env.register_contract(None, PauseManager);
+    let pm_client = PauseManagerClient::new(&env, &pm_id);
+    pm_client.initialize(&operator);
+    payroll_client.set_pause_manager(&pm_id);
+
+    let employee = Address::generate(&env);
+    commitment_client.store_commitment(&employee, &BytesN::from_array(&env, &[0x42u8; 32]));
+
+    TestContext {
+        env,
+        payroll_client,
+        token_client,
+        pause_manager_client: pm_client,
+        admin,
+        treasury,
+        employee,
+    }
+}
+
+fn single_payment_batch(
+    env: &Env,
+    employee: &Address,
+    amount: i128,
+) -> (Vec<BytesN<256>>, Vec<i128>, Vec<Address>) {
+    let mut proofs = Vec::new(env);
+    proofs.push_back(mock_proof(env));
+    let mut amounts = Vec::new(env);
+    amounts.push_back(amount);
+    let mut employees = Vec::new(env);
+    employees.push_back(employee.clone());
+    (proofs, amounts, employees)
+}
+
+#[test]
+fn test_pending_payroll_run_cancellation_cleans_storage_and_preserves_audit_state() {
+    let ctx = setup_test_context();
+    let nonce = test_nonce(&ctx.env, 101);
+    let amount = 50_000i128;
+    let (proofs, amounts, employees) = single_payment_batch(&ctx.env, &ctx.employee, amount);
+
+    let treasury_balance_before = ctx.token_client.balance(&ctx.treasury);
+
+    // 1. Prepare payroll run
+    let run_id = ctx
+        .payroll_client
+        .prepare_payroll_run(&proofs, &amounts, &employees, &amount, &nonce, &None);
+
+    assert!(ctx.payroll_client.get_pending_run(&run_id).is_some());
+    assert_eq!(
+        ctx.payroll_client.get_payroll_run_state(&run_id),
+        PayrollRunState::Submitted
+    );
+
+    let reason = Symbol::new(&ctx.env, "REJECTED_AUDIT_CHECK");
+
+    // 2. Cancel payroll run
+    ctx.payroll_client
+        .cancel_payroll_run_with_reason(&ctx.admin, &run_id, &reason);
+
+    // 3. Verify storage cleanup: pending run removed
+    assert!(
+        ctx.payroll_client.get_pending_run(&run_id).is_none(),
+        "Pending run record must be purged from storage upon cancellation"
+    );
+
+    // 4. Verify no finalized PayrollRun was created
+    assert!(
+        ctx.payroll_client.try_get_payroll_run(&run_id).is_err(),
+        "No completed PayrollRun should exist for a cancelled run"
+    );
+
+    // 5. Verify canonical state is recorded as Cancelled for auditor and reconciler queries
+    assert_eq!(
+        ctx.payroll_client.get_payroll_run_state(&run_id),
+        PayrollRunState::Cancelled,
+        "Canonical state must be recorded as Cancelled"
+    );
+
+    // 6. Verify run nonce remains permanently spent to prevent replay attacks
+    let (p2, a2, e2) = single_payment_batch(&ctx.env, &ctx.employee, amount);
+    let replay_result = ctx
+        .payroll_client
+        .try_prepare_payroll_run(&p2, &a2, &e2, &amount, &nonce, &None);
+    assert!(
+        replay_result.is_err(),
+        "Replay attack with consumed nonce from cancelled run must be rejected"
+    );
+
+    // 7. Verify no funds were moved / deducted from treasury
+    let treasury_balance_after = ctx.token_client.balance(&ctx.treasury);
+    assert_eq!(
+        treasury_balance_before, treasury_balance_after,
+        "Treasury balance must remain untouched after cancellation"
+    );
+
+    // 8. Verify privacy in events: run_cancelled event only contains run_id and reason
+    let events = ctx.env.events().all();
+    let mut found_cancelled_event = false;
+    for event in events.iter() {
+        if event.1.len() >= 2 {
+            let t0_res: Result<Symbol, _> = event.1.get(0).unwrap().try_into_val(&ctx.env);
+            let t1_res: Result<Symbol, _> = event.1.get(1).unwrap().try_into_val(&ctx.env);
+            if let (Ok(topic0), Ok(topic1)) = (t0_res, t1_res) {
+                if topic0 == symbol_short!("payroll")
+                    && topic1 == Symbol::new(&ctx.env, "run_cancelled")
+                {
+                    found_cancelled_event = true;
+                }
+            }
+        }
+    }
+    assert!(found_cancelled_event, "run_cancelled event must be emitted");
+}
+
+#[test]
+fn test_cancelled_run_cannot_be_finalized_or_re_cancelled() {
+    let ctx = setup_test_context();
+    let nonce = test_nonce(&ctx.env, 102);
+    let (proofs, amounts, employees) = single_payment_batch(&ctx.env, &ctx.employee, 25_000i128);
+
+    let run_id = ctx.payroll_client.prepare_payroll_run(
+        &proofs,
+        &amounts,
+        &employees,
+        &25_000i128,
+        &nonce,
+        &None,
+    );
+
+    let reason = Symbol::new(&ctx.env, "CANCELLED_BY_ADMIN");
+    ctx.payroll_client
+        .cancel_payroll_run_with_reason(&ctx.admin, &run_id, &reason);
+
+    // Finalize must fail
+    let finalize_res = ctx
+        .payroll_client
+        .try_finalize_payroll_run(&ctx.admin, &run_id);
+    assert!(
+        finalize_res.is_err(),
+        "Finalizing a cancelled run must fail"
+    );
+
+    // Double cancel must fail
+    let double_cancel_res = ctx
+        .payroll_client
+        .try_cancel_payroll_run_with_reason(&ctx.admin, &run_id, &reason);
+    assert!(
+        double_cancel_res.is_err(),
+        "Cancelling an already cancelled run must fail"
+    );
+}
+
+#[test]
+fn test_cancelled_run_state_is_terminal_and_immutable() {
+    let ctx = setup_test_context();
+
+    // Canonical state machine rules
+    assert!(
+        ctx.payroll_client
+            .is_payroll_state_terminal(&PayrollRunState::Cancelled),
+        "Cancelled state must be terminal"
+    );
+    assert!(
+        !ctx.payroll_client
+            .is_payroll_state_retryable(&PayrollRunState::Cancelled),
+        "Cancelled state must not be retryable"
+    );
+
+    // State transitions out of Cancelled are forbidden
+    assert!(
+        !ctx.payroll_client
+            .is_state_transition_allowed(&PayrollRunState::Cancelled, &PayrollRunState::Completed),
+        "Cancelled -> Completed transition must be forbidden"
+    );
+    assert!(
+        !ctx.payroll_client
+            .is_state_transition_allowed(&PayrollRunState::Cancelled, &PayrollRunState::Submitted),
+        "Cancelled -> Submitted transition must be forbidden"
+    );
+    assert!(
+        !ctx.payroll_client
+            .is_state_transition_allowed(&PayrollRunState::Cancelled, &PayrollRunState::Failed),
+        "Cancelled -> Failed transition must be forbidden"
+    );
+
+    // Conformance test on actual run instance
+    let nonce = test_nonce(&ctx.env, 103);
+    let (proofs, amounts, employees) = single_payment_batch(&ctx.env, &ctx.employee, 10_000i128);
+    let run_id = ctx.payroll_client.prepare_payroll_run(
+        &proofs,
+        &amounts,
+        &employees,
+        &10_000i128,
+        &nonce,
+        &None,
+    );
+
+    ctx.payroll_client.cancel_payroll_run_with_reason(
+        &ctx.admin,
+        &run_id,
+        &Symbol::new(&ctx.env, "CANCEL"),
+    );
+
+    // Attempting state transition hook out of Cancelled must panic
+    let transition_res = ctx.payroll_client.try_transition_payroll_run_state(
+        &ctx.admin,
+        &run_id,
+        &PayrollRunState::Completed,
+    );
+    assert!(
+        transition_res.is_err(),
+        "transition_payroll_run_state out of Cancelled must be rejected"
+    );
+}
+
+#[test]
+fn test_cancellation_authorization_and_validation_errors() {
+    let ctx = setup_test_context();
+    let nonce = test_nonce(&ctx.env, 104);
+    let (proofs, amounts, employees) = single_payment_batch(&ctx.env, &ctx.employee, 15_000i128);
+
+    let run_id = ctx.payroll_client.prepare_payroll_run(
+        &proofs,
+        &amounts,
+        &employees,
+        &15_000i128,
+        &nonce,
+        &None,
+    );
+
+    // 1. Unauthorized caller
+    let attacker = Address::generate(&ctx.env);
+    let unauth_res = ctx.payroll_client.try_cancel_payroll_run_with_reason(
+        &attacker,
+        &run_id,
+        &Symbol::new(&ctx.env, "ATTACK"),
+    );
+    assert!(unauth_res.is_err(), "Unauthorized cancellation must fail");
+
+    // 2. Empty reason symbol
+    let empty_symbol = Symbol::new(&ctx.env, "");
+    let empty_reason_res =
+        ctx.payroll_client
+            .try_cancel_payroll_run_with_reason(&ctx.admin, &run_id, &empty_symbol);
+    assert!(
+        empty_reason_res.is_err(),
+        "Empty reason symbol must be rejected"
+    );
+
+    // 3. Non-existent run ID
+    let non_existent_res = ctx.payroll_client.try_cancel_payroll_run_with_reason(
+        &ctx.admin,
+        &999_999u64,
+        &Symbol::new(&ctx.env, "NON_EXISTENT"),
+    );
+    assert!(
+        non_existent_res.is_err(),
+        "Cancelling non-existent run must fail"
+    );
+
+    // 4. Invalid u64::MAX run ID
+    let invalid_id_res = ctx.payroll_client.try_cancel_payroll_run_with_reason(
+        &ctx.admin,
+        &u64::MAX,
+        &Symbol::new(&ctx.env, "INVALID_ID"),
+    );
+    assert!(
+        invalid_id_res.is_err(),
+        "Cancelling u64::MAX run ID must fail"
+    );
+
+    // 5. Finalized run cannot be cancelled retroactively
+    let finalized_nonce = test_nonce(&ctx.env, 105);
+    let (p2, a2, e2) = single_payment_batch(&ctx.env, &ctx.employee, 20_000i128);
+    let finalized_run_id =
+        ctx.payroll_client
+            .prepare_payroll_run(&p2, &a2, &e2, &20_000i128, &finalized_nonce, &None);
+    ctx.payroll_client
+        .finalize_payroll_run(&ctx.admin, &finalized_run_id);
+
+    let cancel_finalized_res = ctx.payroll_client.try_cancel_payroll_run_with_reason(
+        &ctx.admin,
+        &finalized_run_id,
+        &Symbol::new(&ctx.env, "TOO_LATE"),
+    );
+    assert!(
+        cancel_finalized_res.is_err(),
+        "Cancelling a finalized run must be rejected"
+    );
+}
+
+#[test]
+fn test_escape_hatch_cancellation_under_emergency_pause() {
+    let ctx = setup_test_context();
+    let nonce = test_nonce(&ctx.env, 106);
+    let (proofs, amounts, employees) = single_payment_batch(&ctx.env, &ctx.employee, 30_000i128);
+
+    let run_id = ctx.payroll_client.prepare_payroll_run(
+        &proofs,
+        &amounts,
+        &employees,
+        &30_000i128,
+        &nonce,
+        &None,
+    );
+
+    // Operator pauses contract
+    ctx.pause_manager_client.pause();
+
+    // Verification: normal execution operations (batch_process_payroll and finalize_payroll_run) are blocked
+    let (p2, a2, e2) = single_payment_batch(&ctx.env, &ctx.employee, 10_000i128);
+    let batch_blocked = ctx.payroll_client.try_batch_process_payroll(
+        &p2,
+        &a2,
+        &e2,
+        &10_000i128,
+        &test_nonce(&ctx.env, 107),
+        &None,
+    );
+    assert!(
+        batch_blocked.is_err(),
+        "batch_process_payroll must fail while paused"
+    );
+
+    let finalize_blocked = ctx
+        .payroll_client
+        .try_finalize_payroll_run(&ctx.admin, &run_id);
+    assert!(
+        finalize_blocked.is_err(),
+        "finalize_payroll_run must fail while paused"
+    );
+
+    // Emergency Escape Hatch: cancellation is permitted while paused
+    ctx.payroll_client.cancel_payroll_run_with_reason(
+        &ctx.admin,
+        &run_id,
+        &Symbol::new(&ctx.env, "EMERGENCY_RECOVERY"),
+    );
+
+    // Storage is cleanly purged even during emergency pause
+    assert!(ctx.payroll_client.get_pending_run(&run_id).is_none());
+    assert_eq!(
+        ctx.payroll_client.get_payroll_run_state(&run_id),
+        PayrollRunState::Cancelled
+    );
+}
+
+#[test]
+fn test_sequential_interleaved_runs_lifecycle_with_cancellations() {
+    let ctx = setup_test_context();
+
+    // Run 1: Prepared -> Cancelled
+    let nonce1 = test_nonce(&ctx.env, 110);
+    let (p1, a1, e1) = single_payment_batch(&ctx.env, &ctx.employee, 10_000i128);
+    let run_id_1 =
+        ctx.payroll_client
+            .prepare_payroll_run(&p1, &a1, &e1, &10_000i128, &nonce1, &None);
+    ctx.payroll_client.cancel_payroll_run_with_reason(
+        &ctx.admin,
+        &run_id_1,
+        &Symbol::new(&ctx.env, "REVERT_1"),
+    );
+
+    // Run 2: Prepared -> Finalized -> Reconciled
+    let nonce2 = test_nonce(&ctx.env, 111);
+    let (p2, a2, e2) = single_payment_batch(&ctx.env, &ctx.employee, 20_000i128);
+    let run_id_2 =
+        ctx.payroll_client
+            .prepare_payroll_run(&p2, &a2, &e2, &20_000i128, &nonce2, &None);
+    ctx.payroll_client
+        .finalize_payroll_run(&ctx.admin, &run_id_2);
+    ctx.payroll_client.update_reconciliation_status(
+        &ctx.admin,
+        &run_id_2,
+        &ReconciliationStatus::Reconciled,
+    );
+
+    // Run 3: Prepared -> Cancelled
+    let nonce3 = test_nonce(&ctx.env, 112);
+    let (p3, a3, e3) = single_payment_batch(&ctx.env, &ctx.employee, 30_000i128);
+    let run_id_3 =
+        ctx.payroll_client
+            .prepare_payroll_run(&p3, &a3, &e3, &30_000i128, &nonce3, &None);
+    ctx.payroll_client.cancel_payroll_run_with_reason(
+        &ctx.admin,
+        &run_id_3,
+        &Symbol::new(&ctx.env, "REVERT_3"),
+    );
+
+    // Assert independent distinct run IDs
+    assert_eq!(run_id_1, 1);
+    assert_eq!(run_id_2, 2);
+    assert_eq!(run_id_3, 3);
+
+    // Assert states are cleanly isolated and preserved
+    assert_eq!(
+        ctx.payroll_client.get_payroll_run_state(&run_id_1),
+        PayrollRunState::Cancelled
+    );
+    assert_eq!(
+        ctx.payroll_client.get_payroll_run_state(&run_id_2),
+        PayrollRunState::Completed
+    );
+    assert_eq!(
+        ctx.payroll_client.get_payroll_run_state(&run_id_3),
+        PayrollRunState::Cancelled
+    );
+
+    // Assert pending runs cleaned up
+    assert!(ctx.payroll_client.get_pending_run(&run_id_1).is_none());
+    assert!(ctx.payroll_client.get_pending_run(&run_id_2).is_none());
+    assert!(ctx.payroll_client.get_pending_run(&run_id_3).is_none());
+
+    // Assert only Run 2 has a permanent PayrollRun record
+    assert!(ctx.payroll_client.try_get_payroll_run(&run_id_1).is_err());
+    assert!(ctx.payroll_client.try_get_payroll_run(&run_id_2).is_ok());
+    assert!(ctx.payroll_client.try_get_payroll_run(&run_id_3).is_err());
+}
+
+#[test]
+fn test_draft_cancellation_state_preservation_and_immutability() {
+    let ctx = setup_test_context();
+
+    // 1. Create and amend draft
+    let draft_id = ctx.payroll_client.create_run_draft(
+        &ctx.admin,
+        &50_000i128,
+        &5u32,
+        &Symbol::new(&ctx.env, "OCT_2026"),
+    );
+    ctx.payroll_client
+        .amend_run_draft(&ctx.admin, &draft_id, &60_000i128, &6u32);
+
+    let draft_before = ctx.payroll_client.get_run_draft(&draft_id);
+    assert_eq!(draft_before.state, RunDraftState::Pending);
+    assert_eq!(draft_before.amendment_count, 1);
+
+    // 2. Cancel draft
+    ctx.payroll_client.cancel_run_draft(&ctx.admin, &draft_id);
+
+    // 3. Verify draft record is preserved with state Cancelled for audit history
+    let draft_after = ctx.payroll_client.get_run_draft(&draft_id);
+    assert_eq!(draft_after.state, RunDraftState::Cancelled);
+    assert_eq!(draft_after.draft_id, draft_id);
+    assert_eq!(draft_after.total_amount, 60_000i128);
+    assert_eq!(draft_after.employee_count, 6u32);
+    assert_eq!(draft_after.amendment_count, 1);
+    assert_eq!(draft_after.created_at, draft_before.created_at);
+
+    // 4. Verify terminal status: all further mutations must fail
+    assert!(ctx
+        .payroll_client
+        .is_draft_state_terminal(&RunDraftState::Cancelled));
+    assert!(ctx
+        .payroll_client
+        .try_amend_run_draft(&ctx.admin, &draft_id, &70_000i128, &7u32)
+        .is_err());
+    assert!(ctx
+        .payroll_client
+        .try_finalize_run_draft(&ctx.admin, &draft_id)
+        .is_err());
+    assert!(ctx
+        .payroll_client
+        .try_submit_run_draft(&ctx.admin, &draft_id)
+        .is_err());
+    assert!(ctx
+        .payroll_client
+        .try_cancel_run_draft(&ctx.admin, &draft_id)
+        .is_err());
+    assert!(ctx
+        .payroll_client
+        .try_expire_run_draft(&ctx.admin, &draft_id)
+        .is_err());
+
+    // 5. Recovery: Admin can create a new fresh draft without conflict
+    let new_draft_id = ctx.payroll_client.create_run_draft(
+        &ctx.admin,
+        &50_000i128,
+        &5u32,
+        &Symbol::new(&ctx.env, "OCT_2026_CORRECTED"),
+    );
+    assert_eq!(new_draft_id, draft_id + 1);
+    let new_draft = ctx.payroll_client.get_run_draft(&new_draft_id);
+    assert_eq!(new_draft.state, RunDraftState::Pending);
+}
+
+#[test]
+fn test_finalized_draft_cancellation_flow() {
+    let ctx = setup_test_context();
+
+    let draft_id = ctx.payroll_client.create_run_draft(
+        &ctx.admin,
+        &40_000i128,
+        &4u32,
+        &Symbol::new(&ctx.env, "FINALIZE_THEN_CANCEL"),
+    );
+    ctx.payroll_client.finalize_run_draft(&ctx.admin, &draft_id);
+
+    let finalized_draft = ctx.payroll_client.get_run_draft(&draft_id);
+    assert_eq!(finalized_draft.state, RunDraftState::Finalized);
+
+    // Cancel from finalized state
+    ctx.payroll_client.cancel_run_draft(&ctx.admin, &draft_id);
+
+    let cancelled_draft = ctx.payroll_client.get_run_draft(&draft_id);
+    assert_eq!(cancelled_draft.state, RunDraftState::Cancelled);
+
+    // Submitting cancelled draft must fail
+    assert!(ctx
+        .payroll_client
+        .try_submit_run_draft(&ctx.admin, &draft_id)
+        .is_err());
+}
+
+#[test]
+fn test_draft_cancellation_respects_pause() {
+    let ctx = setup_test_context();
+
+    let draft_id = ctx.payroll_client.create_run_draft(
+        &ctx.admin,
+        &30_000i128,
+        &3u32,
+        &Symbol::new(&ctx.env, "DRAFT_PAUSE"),
+    );
+
+    // Pause contract
+    ctx.pause_manager_client.pause();
+
+    // Draft operations are paused
+    let cancel_res = ctx
+        .payroll_client
+        .try_cancel_run_draft(&ctx.admin, &draft_id);
+    assert!(
+        cancel_res.is_err(),
+        "cancel_run_draft must be rejected when payroll is paused"
+    );
+
+    // Unpause and cancel succeeds
+    ctx.pause_manager_client.unpause();
+    let cancel_after_unpause = ctx
+        .payroll_client
+        .try_cancel_run_draft(&ctx.admin, &draft_id);
+    assert!(cancel_after_unpause.is_ok());
+}

--- a/tests/state/src/lib.rs
+++ b/tests/state/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+mod cancellation_state_cleanup_tests;
+
 use payroll::{Payroll, PayrollClient, RunDraftState};
 use proof_verifier::{ProofVerifier, VerificationKey};
 use salary_commitment::SalaryCommitmentContract;


### PR DESCRIPTION
# PR Description: Add Payroll Cancellation State Cleanup & Audit Tests

## Summary
This PR implements comprehensive integration and state machine tests for payroll run and draft cancellations. It guarantees that cancelled runs cleanly purge transient operational data from contract storage while preserving essential canonical state, audit trails, and replay protection for future reconciliation and compliance. It also resolves a state machine recording defect in `finalize_payroll_run`.

---

## Key Changes

### 1. State Machine & Contract Correction
- **[`contracts/payroll/src/lib.rs`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/zk-payroll-contracts/contracts/payroll/src/lib.rs#L1098)**:
  - Corrected `finalize_payroll_run` line 1098 to record `PayrollRunState::ReconciliationRequired` (instead of mistakenly recording `PayrollRunState::Cancelled`).
  - Added unit test `test_finalize_payroll_run_records_reconciliation_required_and_cleans_pending` ensuring finalized runs properly transition to `ReconciliationRequired` awaiting final reconciliation.

### 2. Comprehensive Test Suite ([`tests/state/src/cancellation_state_cleanup_tests.rs`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/zk-payroll-contracts/tests/state/src/cancellation_state_cleanup_tests.rs))
- **Storage Cleanup & Audit Preservation**:
  - `test_pending_payroll_run_cancellation_cleans_storage_and_preserves_audit_state`:
    - Asserts `PendingPayrollRun` record (`DataKey::PendingRun(run_id)`) is deleted from persistent storage upon cancellation (`get_pending_run` returns `None`).
    - Asserts no completed `PayrollRun` record is created (`get_payroll_run` fails).
    - Asserts canonical state is recorded as `PayrollRunState::Cancelled` in `DataKey::PayrollState(run_id)` for reconcilers and auditors.
    - Asserts `RunNonce` remains consumed to prevent replay attacks with the same batch nonce.
    - Asserts treasury token balances remain untouched (no funds transferred).
    - Asserts `run_cancelled` event is emitted with non-sensitive topics `(run_id, reason)`.
- **Terminal Invariant & Double-Action Protection**:
  - `test_cancelled_run_cannot_be_finalized_or_re_cancelled`: Validates that trying to finalize or re-cancel a cancelled run fails.
  - `test_cancelled_run_state_is_terminal_and_immutable`: Validates that `Cancelled` is terminal, non-retryable, and blocks state transition hooks.
- **Authorization & Validation Error Paths**:
  - `test_cancellation_authorization_and_validation_errors`: Validates unauthorized non-admin rejection (`Unauthorized`), empty reason symbol rejection (`Symbol cannot be empty`), non-existent run ID rejection (`Pending run not found`), invalid ID boundary validation (`u64::MAX`), and rejection of cancelling already finalized runs (`Cannot cancel a finalized payroll run`).
- **Emergency Incident Response Escape Hatch**:
  - `test_escape_hatch_cancellation_under_emergency_pause`: Validates that while standard batch execution and finalization are blocked when paused, cancellation remains operational to allow operators to clean up pending runs during an emergency pause.
- **Sequential Multi-Run Interleaving**:
  - `test_sequential_interleaved_runs_lifecycle_with_cancellations`: Validates that sequential runs with alternating cancellations and finalizations maintain complete state isolation without cross-contamination.
- **Draft Lifecycle Cancellation**:
  - `test_draft_cancellation_state_preservation_and_immutability`: Validates that cancelling a draft transitions to `RunDraftState::Cancelled`, preserves historical metadata (`created_at`, `total_amount`, `employee_count`, `amendment_count`), blocks further mutations, and allows subsequent draft creation.
  - `test_finalized_draft_cancellation_flow`: Validates transition from `Finalized` to `Cancelled`.
  - `test_draft_cancellation_respects_pause`: Validates `cancel_run_draft` respects active contract pause status.

### 3. Documentation Updates
- **[`docs/payroll-state-machine.md`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/zk-payroll-contracts/docs/payroll-state-machine.md)**:
  - Added dedicated section **"Cancellation State Cleanup & Audit Preservation"** specifying active storage cleanup, audit preservation, replay protection, treasury safety, escape hatch semantics, and privacy compliance.
- **[`docs/state-machine.md`](file:///c:/Users/hp/OneDrive/Desktop/GrantFox/zk-payroll-contracts/docs/state-machine.md)**:
  - Added section **"3. Cancellation & State Cleanup Semantics"** detailing storage cleanup, draft immutability, and privacy rules.

---

## Privacy Compliance
- `run_cancelled` events emit only `(run_id, reason)`.
- `draft_cancelled` events emit only `(draft_id, admin)`.
- No individual employee salary values, bank accounts, or commitment secrets are exposed in logs, events, or state.

---

## Verification & Test Results
- `cargo test -p state_tests` (14/14 passed)
- `cargo test` (all workspace tests passed)
- `cargo clippy --all-targets` (0 warnings, 0 errors)
- `cargo fmt --all -- --check` (0 formatting issues)

Closes #270 