### PR TITLE
feat: add contract proof reference expiry checks (#251)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ name = "payroll"
 version = "0.1.0"
 dependencies = [
  "pause_manager",
+ "payroll_events",
  "payroll_registry",
  "proof_verifier",
  "salary_commitment",

--- a/contracts/proof_verifier/src/expiry_tests.rs
+++ b/contracts/proof_verifier/src/expiry_tests.rs
@@ -1,0 +1,402 @@
+//! Issue #251 — proof reference expiry checks.
+//!
+//! Covers valid, expired, missing, and revoked proof references plus
+//! boundary timing behaviour around `expires_at_ledger`.
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger as _;
+use soroban_sdk::{Env, Vec};
+
+fn mock_verification_key(env: &Env) -> VerificationKey {
+    VerificationKey {
+        alpha: BytesN::from_array(env, &[1u8; 64]),
+        beta: BytesN::from_array(env, &[2u8; 128]),
+        gamma: BytesN::from_array(env, &[3u8; 128]),
+        delta: BytesN::from_array(env, &[4u8; 128]),
+        ic: Vec::from_array(
+            env,
+            [
+                BytesN::from_array(env, &[5u8; 64]),
+                BytesN::from_array(env, &[6u8; 64]),
+                BytesN::from_array(env, &[7u8; 64]),
+            ],
+        ),
+    }
+}
+
+fn mock_proof(env: &Env) -> BytesN<256> {
+    BytesN::from_array(env, &[8u8; 256])
+}
+
+fn other_proof(env: &Env) -> BytesN<256> {
+    BytesN::from_array(env, &[9u8; 256])
+}
+
+fn public_inputs(env: &Env) -> Vec<BytesN<32>> {
+    Vec::from_array(
+        env,
+        [
+            BytesN::from_array(env, &[10u8; 32]),
+            BytesN::from_array(env, &[11u8; 32]),
+        ],
+    )
+}
+
+fn setup(env: &Env) -> (ProofVerifierClient<'_>, soroban_sdk::Address) {
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ProofVerifier);
+    let client = ProofVerifierClient::new(env, &contract_id);
+    let admin = soroban_sdk::Address::generate(env);
+    client.init_verifier_admin(&admin);
+    client.initialize_verifier(&mock_verification_key(env));
+    (client, admin)
+}
+
+const REF: [u8; 32] = [42u8; 32];
+
+/// Valid reference authorizes verification before its expiry.
+#[test]
+fn valid_reference_authorizes_verification() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    let registered = client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &(100u32),
+    );
+
+    assert_eq!(registered.registered_at_ledger, 0);
+    assert_eq!(registered.expires_at_ledger, 100);
+    assert!(!registered.revoked);
+
+    assert!(client.is_proof_reference_valid(&BytesN::from_array(&env, &REF)));
+    assert!(
+        client.verify_with_reference(
+            &BytesN::from_array(&env, &REF),
+            &mock_proof(&env),
+            &public_inputs(&env)
+        ),
+        "valid reference must authorize proof verification"
+    );
+}
+
+/// A reference that was never registered must not authorize anything.
+#[test]
+fn missing_reference_is_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let unknown = BytesN::from_array(&env, &[7u8; 32]);
+    assert!(!client.is_proof_reference_valid(&unknown));
+    assert_eq!(
+        client
+            .try_get_proof_reference(&unknown)
+            .unwrap_err()
+            .unwrap(),
+        ProofError::ReferenceNotFound
+    );
+    assert!(
+        !client.verify_with_reference(&unknown, &mock_proof(&env), &public_inputs(&env)),
+        "missing reference must be rejected"
+    );
+}
+
+/// An expired reference must not authorize verification.
+#[test]
+fn expired_reference_is_rejected() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &(50u32),
+    );
+
+    env.ledger().set_sequence_number(60);
+
+    assert!(!client.is_proof_reference_valid(&BytesN::from_array(&env, &REF)));
+    assert!(
+        !client.verify_with_reference(
+            &BytesN::from_array(&env, &REF),
+            &mock_proof(&env),
+            &public_inputs(&env)
+        ),
+        "expired reference must be rejected"
+    );
+    // The record is still queryable for audit tooling.
+    let stored = client.get_proof_reference(&BytesN::from_array(&env, &REF));
+    assert_eq!(stored.expires_at_ledger, 50);
+}
+
+// -------------------------------------------------------------------------
+// Boundary timing behaviour
+// -------------------------------------------------------------------------
+
+#[test]
+fn boundary_valid_one_ledger_before_expiry() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    let expires_at = 30u32;
+    client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &expires_at,
+    );
+
+    env.ledger().set_sequence_number(expires_at - 1);
+    assert!(
+        client.is_proof_reference_valid(&BytesN::from_array(&env, &REF)),
+        "reference must remain usable at expires_at - 1"
+    );
+
+    // Matches audit_module's convention: still valid AT the expiry ledger.
+    env.ledger().set_sequence_number(expires_at);
+    assert!(
+        client.is_proof_reference_valid(&BytesN::from_array(&env, &REF)),
+        "reference must remain usable at expires_at itself"
+    );
+}
+
+#[test]
+fn boundary_expired_one_ledger_after_expiry() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    let expires_at = 30u32;
+    client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &expires_at,
+    );
+
+    env.ledger().set_sequence_number(expires_at + 1);
+    assert!(
+        !client.is_proof_reference_valid(&BytesN::from_array(&env, &REF)),
+        "reference must be expired from expires_at + 1 onward"
+    );
+    assert!(!client.verify_with_reference(
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &public_inputs(&env)
+    ));
+}
+
+#[test]
+fn boundary_expired_verification_rejected_after_expiry() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    let expires_at = 30u32;
+    client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &expires_at,
+    );
+
+    env.ledger().set_sequence_number(expires_at + 5);
+    assert!(!client.is_proof_reference_valid(&BytesN::from_array(&env, &REF)));
+    assert!(!client.verify_with_reference(
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &public_inputs(&env)
+    ));
+}
+
+// -------------------------------------------------------------------------
+// Registration validation rules
+// -------------------------------------------------------------------------
+
+#[test]
+fn registration_rejects_expiry_in_the_past_or_present() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    env.ledger().set_sequence_number(10);
+
+    // Equal to current ledger → invalid.
+    assert_eq!(
+        client
+            .try_register_proof_reference(
+                &admin,
+                &BytesN::from_array(&env, &REF),
+                &mock_proof(&env),
+                &(10u32)
+            )
+            .unwrap_err()
+            .unwrap(),
+        ProofError::InvalidExpiry
+    );
+
+    // Before current ledger → invalid.
+    assert_eq!(
+        client
+            .try_register_proof_reference(
+                &admin,
+                &BytesN::from_array(&env, &REF),
+                &mock_proof(&env),
+                &(5u32)
+            )
+            .unwrap_err()
+            .unwrap(),
+        ProofError::InvalidExpiry
+    );
+}
+
+#[test]
+fn registration_rejects_ttl_beyond_cap() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    env.ledger().set_sequence_number(0);
+    let too_far = MAX_REFERENCE_TTL_LEDGERS + 1;
+    assert_eq!(
+        client
+            .try_register_proof_reference(
+                &admin,
+                &BytesN::from_array(&env, &REF),
+                &mock_proof(&env),
+                &too_far
+            )
+            .unwrap_err()
+            .unwrap(),
+        ProofError::ExpiryBeyondCap
+    );
+
+    // Exactly the cap is allowed.
+    client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &MAX_REFERENCE_TTL_LEDGERS,
+    );
+}
+
+#[test]
+fn duplicate_ref_id_is_rejected() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &(100u32),
+    );
+
+    assert_eq!(
+        client
+            .try_register_proof_reference(
+                &admin,
+                &BytesN::from_array(&env, &REF),
+                &other_proof(&env),
+                &(200u32)
+            )
+            .unwrap_err()
+            .unwrap(),
+        ProofError::ReferenceAlreadyExists
+    );
+}
+
+#[test]
+fn non_admin_cannot_register() {
+    let env = Env::default();
+    // No mock_all_auths here: a non-admin address has no way to satisfy
+    // admin.require_auth(), so registration must be rejected.
+    let contract_id = env.register_contract(None, ProofVerifier);
+    let client = ProofVerifierClient::new(&env, &contract_id);
+    let attacker = soroban_sdk::Address::generate(&env);
+    let result = client.try_register_proof_reference(
+        &attacker,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &(100u32),
+    );
+    assert!(result.is_err(), "non-admin registration must be rejected");
+}
+
+// -------------------------------------------------------------------------
+// Revocation and proof binding
+// -------------------------------------------------------------------------
+
+#[test]
+fn revoked_reference_is_rejected_even_before_expiry() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &(1000u32),
+    );
+    client.revoke_proof_reference(&admin, &BytesN::from_array(&env, &REF));
+
+    assert!(!client.is_proof_reference_valid(&BytesN::from_array(&env, &REF)));
+    assert!(!client.verify_with_reference(
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &public_inputs(&env)
+    ));
+}
+
+#[test]
+fn revoking_unknown_reference_fails() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    assert_eq!(
+        client
+            .try_revoke_proof_reference(&admin, &BytesN::from_array(&env, &REF))
+            .unwrap_err()
+            .unwrap(),
+        ProofError::ReferenceNotFound
+    );
+}
+
+#[test]
+fn reference_does_not_authorize_different_proof_bytes() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.register_proof_reference(
+        &admin,
+        &BytesN::from_array(&env, &REF),
+        &mock_proof(&env),
+        &(1000u32),
+    );
+
+    assert!(
+        !client.verify_with_reference(
+            &BytesN::from_array(&env, &REF),
+            &other_proof(&env),
+            &public_inputs(&env)
+        ),
+        "a reference must only authorize its own proof material"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Existing workflows unaffected
+// -------------------------------------------------------------------------
+
+#[test]
+fn unregistered_direct_verification_still_works() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    // Issue #251 must not break existing proof paths that do not use
+    // references.
+    assert!(
+        client.verify_payment_proof(&mock_proof(&env), &public_inputs(&env)),
+        "valid proofs continue to work without a reference"
+    );
+}

--- a/contracts/proof_verifier/src/lib.rs
+++ b/contracts/proof_verifier/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, BytesN, Env, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Bytes, BytesN, Env, Vec};
 
 /// Groth16 proof components (G1 A, G2 B, G1 C) for BN254.
 #[contracttype]
@@ -21,11 +21,51 @@ pub struct VerificationKey {
     pub ic: Vec<BytesN<64>>,
 }
 
+/// A registered reference to a specific proof, carrying an explicit expiry.
+///
+/// Issue #251: proof references authorize payroll actions and audit access,
+/// so they must never remain usable past their expiration ledger. Following
+/// the `audit_module` convention, a reference is valid while
+/// `current_ledger_sequence <= expires_at_ledger` and it has not been
+/// revoked.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProofReference {
+    /// SHA-256 of the exact proof bytes this reference authorizes. The
+    /// digest is computed on-chain at registration so a reference can never
+    /// be replayed against different proof material.
+    pub proof_hash: BytesN<32>,
+    pub registered_at_ledger: u32,
+    /// First ledger sequence at which the reference is no longer usable.
+    pub expires_at_ledger: u32,
+    pub revoked: bool,
+}
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ProofError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    ReferenceAlreadyExists = 3,
+    ReferenceNotFound = 4,
+    ReferenceExpired = 5,
+    ReferenceRevoked = 6,
+    InvalidExpiry = 7,
+    ExpiryBeyondCap = 8,
+    ProofMismatch = 9,
+}
+
 #[contracttype]
 pub enum DataKey {
     VerificationKey,
     Admin,
+    ProofReference(BytesN<32>),
 }
+
+/// Upper bound for a reference lifetime (~30 days of ledgers at 5s each).
+/// Prevents an operator mistake from creating effectively eternal proofs.
+pub const MAX_REFERENCE_TTL_LEDGERS: u32 = 518_400;
 
 #[contract]
 pub struct ProofVerifier;
@@ -87,6 +127,170 @@ impl ProofVerifier {
         Self::simulated_verify_groth16(&env, &vk, proof, public_inputs)
     }
 
+    // ------------------------------------------------------------------
+    // Proof reference expiry (issue #251)
+    // ------------------------------------------------------------------
+
+    /// Register an expiring reference to `proof`.
+    ///
+    /// Expiry rules:
+    /// - `expires_at_ledger` must be strictly greater than the current
+    ///   ledger sequence (`ProofError::InvalidExpiry` otherwise).
+    /// - The resulting time-to-live may not exceed
+    ///   [`MAX_REFERENCE_TTL_LEDGERS`] (`ProofError::ExpiryBeyondCap`).
+    /// - Each `ref_id` can be registered only once
+    ///   (`ProofError::ReferenceAlreadyExists`).
+    ///
+    /// Emits a `ProofRefRegistered` event on success.
+    pub fn register_proof_reference(
+        env: Env,
+        admin: soroban_sdk::Address,
+        ref_id: BytesN<32>,
+        proof: BytesN<256>,
+        expires_at_ledger: u32,
+    ) -> Result<ProofReference, ProofError> {
+        admin.require_auth();
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::ProofReference(ref_id.clone()))
+        {
+            return Err(ProofError::ReferenceAlreadyExists);
+        }
+
+        let current = env.ledger().sequence();
+        if expires_at_ledger <= current {
+            return Err(ProofError::InvalidExpiry);
+        }
+        if expires_at_ledger.saturating_sub(current) > MAX_REFERENCE_TTL_LEDGERS {
+            return Err(ProofError::ExpiryBeyondCap);
+        }
+
+        let reference = ProofReference {
+            proof_hash: Self::proof_digest(&env, &proof),
+            registered_at_ledger: current,
+            expires_at_ledger,
+            revoked: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProofReference(ref_id.clone()), &reference);
+
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "ProofRefRegistered"), ref_id),
+            (expires_at_ledger,),
+        );
+
+        Ok(reference)
+    }
+
+    /// Revoke a reference before its expiry. Revocation is permanent: an
+    /// expired-and-then-revoked reference stays rejected either way.
+    ///
+    /// Emits a `ProofRefRevoked` event on success.
+    pub fn revoke_proof_reference(
+        env: Env,
+        admin: soroban_sdk::Address,
+        ref_id: BytesN<32>,
+    ) -> Result<(), ProofError> {
+        admin.require_auth();
+
+        let key = DataKey::ProofReference(ref_id.clone());
+        let mut reference: ProofReference = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(ProofError::ReferenceNotFound)?;
+        reference.revoked = true;
+        env.storage().persistent().set(&key, &reference);
+
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "ProofRefRevoked"), ref_id),
+            (),
+        );
+
+        Ok(())
+    }
+
+    /// Return the stored reference record.
+    pub fn get_proof_reference(env: Env, ref_id: BytesN<32>) -> Result<ProofReference, ProofError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ProofReference(ref_id))
+            .ok_or(ProofError::ReferenceNotFound)
+    }
+
+    /// Whether `ref_id` currently authorizes actions: registered, not
+    /// revoked, and not yet expired.
+    ///
+    /// Boundary semantics (matching `audit_module` view keys): a reference
+    /// remains usable through the ledger whose sequence equals
+    /// `expires_at_ledger`; from `expires_at_ledger + 1` onward it is
+    /// expired.
+    pub fn is_proof_reference_valid(env: Env, ref_id: BytesN<32>) -> bool {
+        match env
+            .storage()
+            .persistent()
+            .get::<DataKey, ProofReference>(&DataKey::ProofReference(ref_id))
+        {
+            Some(reference) => Self::reference_is_current(&env, &reference).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Verify a proof through its registered reference (issue #251).
+    ///
+    /// This is the enforcement point for expiry-sensitive consumers: unlike
+    /// [`verify_payment_proof`], a missing, expired, or revoked reference —
+    /// or proof bytes that differ from the ones the reference was created
+    /// for — makes verification fail without authorizing anything.
+    ///
+    /// Returns `false` (rather than panicking) so cross-contract callers can
+    /// treat an unusable reference uniformly as "not authorized".
+    pub fn verify_with_reference(
+        env: Env,
+        ref_id: BytesN<32>,
+        proof: BytesN<256>,
+        public_inputs: Vec<BytesN<32>>,
+    ) -> bool {
+        let reference: ProofReference = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProofReference(ref_id))
+        {
+            Some(reference) => reference,
+            None => return false,
+        };
+        if !Self::reference_is_current(&env, &reference).is_ok() {
+            return false;
+        }
+        if reference.proof_hash != Self::proof_digest(&env, &proof) {
+            return false;
+        }
+        Self::verify_payment_proof(env, proof, public_inputs)
+    }
+
+    /// A reference is current while unrevoked and not past its expiry
+    /// ledger. Following `audit_module`'s convention, expiry starts at
+    /// `sequence() > expires_at_ledger`.
+    fn reference_is_current(env: &Env, reference: &ProofReference) -> Result<(), ProofError> {
+        if reference.revoked {
+            return Err(ProofError::ReferenceRevoked);
+        }
+        if env.ledger().sequence() > reference.expires_at_ledger {
+            return Err(ProofError::ReferenceExpired);
+        }
+        Ok(())
+    }
+
+    fn proof_digest(env: &Env, proof: &BytesN<256>) -> BytesN<32> {
+        env.crypto()
+            .sha256(&Bytes::from_array(env, &proof.to_array()))
+            .into()
+    }
+
     fn pack_groth16_proof(env: &Env, proof: &Groth16Proof) -> BytesN<256> {
         let mut buf = [0u8; 256];
         buf[..64].copy_from_slice(&proof.a.to_array());
@@ -116,3 +320,6 @@ impl ProofVerifier {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod expiry_tests;

--- a/docs/security/proof-reference-expiry.md
+++ b/docs/security/proof-reference-expiry.md
@@ -1,0 +1,84 @@
+# Proof Reference Expiry (Issue #251)
+
+## Summary
+
+Proof references are on-chain records in the `proof_verifier` contract that
+bind a specific Groth16 proof to an explicit expiration. They exist so that
+expiry-sensitive consumers — payroll execution paths and audit access
+workflows — can gate authorization on a reference instead of treating every
+submitted proof as eternally valid.
+
+**Core rule: an expired, revoked, or missing proof reference never authorizes
+a payroll action or audit action.**
+
+## Contract surface
+
+All of the following live in `contracts/proof_verifier/src/lib.rs`.
+
+| Function | Purpose |
+| --- | --- |
+| `register_proof_reference(admin, ref_id, proof, expires_at_ledger)` | Admin-only. Registers `ref_id` for the exact `proof` bytes (SHA-256 digest is computed on-chain) with an explicit expiry ledger. |
+| `revoke_proof_reference(admin, ref_id)` | Admin-only. Permanently revokes before or after expiry; revocation is irreversible. |
+| `get_proof_reference(ref_id)` | Returns the stored record (`proof_hash`, `registered_at_ledger`, `expires_at_ledger`, `revoked`). |
+| `is_proof_reference_valid(ref_id)` | Read-only check used by tooling: registered ∧ not revoked ∧ not expired. |
+| `verify_with_reference(ref_id, proof, public_inputs)` | Enforcement point: verifies the proof **only through** its reference. Missing / expired / revoked / mismatched proofs return `false` instead of authorizing. |
+
+## Expiry rules
+
+1. **Registration validation**
+   - `expires_at_ledger` must be strictly greater than the current ledger
+     sequence (`ProofError::InvalidExpiry` otherwise). References cannot be
+     created already expired.
+   - Time-to-live is capped at `MAX_REFERENCE_TTL_LEDGERS` = 518,400 ledgers
+     (~30 days at 5 s ledgers). Anything longer fails with
+     `ProofError::ExpiryBeyondCap`, preventing operator mistakes from minting
+     effectively eternal proofs.
+   - Each `ref_id` can only be registered once
+     (`ProofError::ReferenceAlreadyExists`).
+   - Only the verifier admin may register or revoke.
+
+2. **Validity boundary** (matches the `audit_module` view-key convention)
+   - A reference is usable while `ledger.sequence() <= expires_at_ledger`.
+   - From `expires_at_ledger + 1` onward it is expired
+     (`ProofError::ReferenceExpired`) and `verify_with_reference` returns
+     `false`.
+
+3. **Revocation**
+   - `revoke_proof_reference` flips `revoked` permanently. Revoked references
+     fail validity immediately regardless of expiry
+     (`ProofError::ReferenceRevoked`).
+
+4. **Binding to proof material**
+   - Registration stores `sha256(proof)`. `verify_with_reference` recomputes
+     the digest at verification time and rejects any other proof bytes
+     (`ProofError::ProofMismatch` path → `false`), so a valid reference can
+     never be replayed against different proof material.
+
+5. **Missing references**
+   - Verification through an unregistered `ref_id` returns `false`
+     (`ProofError::ReferenceNotFound` from getters). Silence is treated as
+     "not authorized".
+
+## Failure semantics
+
+`verify_with_reference` deliberately returns `false` rather than panicking:
+cross-contract callers (payroll batches, audit tooling) should treat any
+`false` as "this proof does not authorize the action" and skip/reject the
+record. This keeps expiry failures uniform with cryptographic verification
+failures.
+
+Existing direct verification (`verify_payment_proof`, `verify`) is unchanged;
+references are opt-in for consumers that need expiry guarantees.
+
+## Test coverage
+
+See `contracts/proof_verifier/src/expiry_tests.rs`:
+
+- Valid reference authorizes verification.
+- Missing, expired, and revoked references are rejected.
+- Boundary timing: usable at `expires_at_ledger - 1` **and** at
+  `expires_at_ledger`; rejected from `expires_at_ledger + 1` onward.
+- Registration rejects past/present expiry, TTL beyond cap, duplicate ids,
+  and non-admin callers.
+- A reference does not authorize different proof bytes.
+- Direct verification without references continues to work.


### PR DESCRIPTION
Closes #251

## Problem

Proofs submitted to the system had no expiry semantics at the contract layer: a proof, once valid, remained usable indefinitely. Expired proof references could still authorize payroll actions or audit access because there was no mechanism to define, enforce, or observe reference lifetime.

## Solution

### Proof reference registry (`contracts/proof_verifier/src/lib.rs`)

New `ProofReference` record bound to the **exact** proof bytes via an on-chain `sha256(proof)` digest (computed inside the contract at registration — no off-chain hashing to get wrong):

```rust
pub struct ProofReference {
    pub proof_hash: BytesN<32>,       // binds ref -> exact proof material
    pub registered_at_ledger: u32,
    pub expires_at_ledger: u32,       // first unusable ledger is +1
    pub revoked: bool,
}
```

New admin functions:
- `register_proof_reference(admin, ref_id, proof, expires_at_ledger)` — registers with explicit expiry
- `revoke_proof_reference(admin, ref_id)` — permanent revocation
- `get_proof_reference(ref_id)` / `is_proof_reference_valid(ref_id)` — query surface for tooling

New enforcement point:
- `verify_with_reference(ref_id, proof, public_inputs) -> bool` — verifies a proof **through** its reference. Missing, expired, or revoked references — and any proof bytes other than those the reference was created for — return `false` instead of authorizing.

### Expiry rules defined

1. `expires_at_ledger` must be strictly in the future (`InvalidExpiry`)
2. TTL capped at `MAX_REFERENCE_TTL_LEDGERS = 518_400` (~30 days) (`ExpiryBeyondCap`) — no eternal proofs
3. Duplicate `ref_id` rejected (`ReferenceAlreadyExists`)
4. Boundary matches the existing `audit_module` view-key convention: usable through `expires_at_ledger`, expired from `expires_at_ledger + 1`
5. Revocation is immediate and permanent (`ReferenceRevoked`)
6. Missing references are "not authorized" — never a bypass

Existing `verify_payment_proof` / `verify` behavior is unchanged; references are opt-in for expiry-sensitive consumers.

### Tests (`contracts/proof_verifier/src/expiry_tests.rs`)

13 new tests, full suite **40 passed / 0 failed**:

| Coverage | Tests |
|---|---|
| Valid reference authorizes verification | ✅ |
| Missing reference rejected | ✅ |
| Expired reference rejected | ✅ |
| Boundary timing: valid at `-1` and **at** expiry ledger; rejected from `+1` | ✅ 3 tests |
| Registration validation (past/present expiry, cap, duplicates, non-admin) | ✅ 4 tests |
| Revocation before expiry + unknown-ref revocation | ✅ 2 tests |
| Reference does not authorize different proof bytes | ✅ |
| Direct verification without references still works | ✅ |

### Docs (`docs/security/proof-reference-expiry.md`)

Documents the contract surface, all expiry rules, boundary semantics, failure semantics (return-`false`-not-panic rationale for cross-contract callers), and the test matrix.

## Verification
- `cargo test -p proof_verifier`: 40 passed
- `cargo build -p proof_verifier --target wasm32-unknown-unknown --release`: clean
- `cargo clippy -p proof_verifier --all-targets`: clean
- `cargo fmt`: applied