### PR TITLE
Add settlement state transition tests (issue #254)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "settlement_state_tests"
+version = "0.1.0"
+dependencies = [
+ "pause_manager",
+ "payroll",
+ "proof_verifier",
+ "salary_commitment",
+ "soroban-sdk",
+ "token",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "tests/storage",
     "tests/access-control",
     "tests/events",
+    "tests/settlement",
 ]
 exclude = ["fuzz"]
 

--- a/docs/settlement-state-machine.md
+++ b/docs/settlement-state-machine.md
@@ -1,0 +1,87 @@
+# Settlement State Machine
+
+Issue #254 documents the canonical settlement lifecycle that the payroll
+contract, SDKs, and dashboards must mirror. The contract source of truth is
+`PayrollRunState` in `contracts/payroll/src/lib.rs`; the transition rules are
+enforced by `is_allowed_payroll_state_transition_internal` and exposed for
+operations through `transition_payroll_run_state`. The machine-readable mirror
+is `fixtures/state-machine/settlement-state-machine.json`.
+
+## Settlement Phases
+
+The issue describes settlement in five high-level phases; they map onto the
+concrete `PayrollRunState` variants below.
+
+| Settlement phase (issue #254) | `PayrollRunState` | Terminal | Retryable | Meaning |
+| --- | --- | --- | --- | --- |
+| `pending` | `Submitted` | No | No | Run prepared, awaiting settlement/confirmation. |
+| `executing` | `Confirming` | No | No | Settlement/confirmation in progress. |
+| `settled` | `Completed` | Yes | No | Settlement finalized; immutable. |
+| `failed` | `Failed` | No | Yes | Settlement failed; the only retryable state. |
+| `cancelled` | `Cancelled` | Yes | No | Run cancelled; immutable. |
+
+The full concrete state set also includes the pre-settlement drafting stages
+(`Draft`, `Validating`, `ProofPending`, `ReadyToSubmit`) and the
+`ReconciliationRequired` review stage that `Confirming` may enter before
+`Completed`.
+
+## Allowed Transitions
+
+| From | To | Settlement meaning |
+| --- | --- | --- |
+| `Draft` | `Validating` | Begin validating a draft run. |
+| `Draft` | `Cancelled` | Cancel a run before validation. |
+| `Validating` | `ProofPending` | Inputs passed validation; proof work can start. |
+| `Validating` | `Failed` | Validation failed; the run can be retried. |
+| `Validating` | `Cancelled` | Cancel a run during validation. |
+| `ProofPending` | `ReadyToSubmit` | Proof artifacts ready. |
+| `ProofPending` | `Failed` | Proof generation/verification failed. |
+| `ProofPending` | `Cancelled` | Cancel a run while proofs are pending. |
+| `ReadyToSubmit` | `Submitted` | Submit the prepared run on-chain (`pending`). |
+| `ReadyToSubmit` | `Failed` | Submission preparation failed. |
+| `ReadyToSubmit` | `Cancelled` | Cancel a run before on-chain submission. |
+| `Submitted` (`pending`) | `Confirming` (`executing`) | Begin settlement. |
+| `Submitted` (`pending`) | `Failed` | Submission failed before confirmation. |
+| `Submitted` (`pending`) | `Cancelled` | Cancel a prepared run before settlement. |
+| `Confirming` (`executing`) | `Completed` (`settled`) | Settlement finalized. |
+| `Confirming` (`executing`) | `Failed` | Settlement failed; retryable. |
+| `Confirming` (`executing`) | `ReconciliationRequired` | Executed; must be reconciled before settlement closes. |
+| `Failed` | `Validating` | Retry from validation. |
+| `Failed` | `ProofPending` | Retry from proof generation when inputs remain valid. |
+| `Failed` | `Cancelled` | Cancel a failed run. |
+| `ReconciliationRequired` | `Completed` (`settled`) | Reconciliation complete; settlement closes. |
+| `ReconciliationRequired` | `Failed` | Reconciliation failed; retryable. |
+
+## Blocked Transitions
+
+| Operation | Outcome |
+| --- | --- |
+| Any transition into `Draft` | Rejected — `Draft` is only an initial state. |
+| `Completed` (`settled`) → anything | Rejected — terminal/immutable (settlement cannot be replayed). |
+| `Cancelled` → anything | Rejected — terminal/immutable. |
+| Non-adjacent transitions (e.g. `Submitted` → `Completed`) | Rejected — the canonical matrix only allows single-step moves. |
+| Transition without the company admin's authorization | Rejected (`require_auth` fails). |
+
+## Reference Implementation Tests
+
+The behaviour on this page is pinned by the integration suite in
+`tests/settlement/`:
+
+| Suite | Coverage |
+| --- | --- |
+| `settlement_transitions.rs` | Full 10 × 10 transition matrix matches the documented rules; every valid transition is applied on-chain; invalid transitions panic with `Invalid payroll state transition`; `settled`/`cancelled` reject all further moves; only `failed` is retryable; non-admin transitions are rejected. |
+
+Run them with:
+
+```bash
+cargo test -p settlement_state_tests
+```
+
+## Relationship to Reconciliation
+
+Settlement finalization (`Confirming` → `Completed`) is driven by
+`update_reconciliation_status`, which maps `Reconciled` → `Completed`,
+`Unreconciled` → `ReconciliationRequired`, and `Failed` → `Failed`. The same
+function enforces the *settlement completion is final* guard (issue #244): once
+a run is `Completed` any further reconciliation update is rejected, preventing
+double settlement.

--- a/fixtures/state-machine/settlement-state-machine.json
+++ b/fixtures/state-machine/settlement-state-machine.json
@@ -1,0 +1,59 @@
+{
+  "version": 1,
+  "issue": 254,
+  "source": "contracts/payroll/src/lib.rs::PayrollRunState",
+  "documentation": "docs/state-machine.md",
+  "settlement_phases": {
+    "pending": "Submitted",
+    "executing": "Confirming",
+    "settled": "Completed",
+    "failed": "Failed",
+    "cancelled": "Cancelled"
+  },
+  "states": [
+    { "name": "draft", "variant": "Draft", "ordinal": 0, "terminal": false, "retryable": false, "settlement_phase": null },
+    { "name": "validating", "variant": "Validating", "ordinal": 1, "terminal": false, "retryable": false, "settlement_phase": null },
+    { "name": "proof_pending", "variant": "ProofPending", "ordinal": 2, "terminal": false, "retryable": false, "settlement_phase": null },
+    { "name": "ready_to_submit", "variant": "ReadyToSubmit", "ordinal": 3, "terminal": false, "retryable": false, "settlement_phase": null },
+    { "name": "pending", "variant": "Submitted", "ordinal": 4, "terminal": false, "retryable": false, "settlement_phase": "pending" },
+    { "name": "executing", "variant": "Confirming", "ordinal": 5, "terminal": false, "retryable": false, "settlement_phase": "executing" },
+    { "name": "settled", "variant": "Completed", "ordinal": 6, "terminal": true, "retryable": false, "settlement_phase": "settled" },
+    { "name": "failed", "variant": "Failed", "ordinal": 7, "terminal": false, "retryable": true, "settlement_phase": "failed" },
+    { "name": "cancelled", "variant": "Cancelled", "ordinal": 8, "terminal": true, "retryable": false, "settlement_phase": "cancelled" },
+    { "name": "reconciliation_required", "variant": "ReconciliationRequired", "ordinal": 9, "terminal": false, "retryable": false, "settlement_phase": null }
+  ],
+  "allowed_transitions": [
+    { "from": "draft", "to": "validating" },
+    { "from": "draft", "to": "cancelled" },
+    { "from": "validating", "to": "proof_pending" },
+    { "from": "validating", "to": "failed" },
+    { "from": "validating", "to": "cancelled" },
+    { "from": "proof_pending", "to": "ready_to_submit" },
+    { "from": "proof_pending", "to": "failed" },
+    { "from": "proof_pending", "to": "cancelled" },
+    { "from": "ready_to_submit", "to": "submitted" },
+    { "from": "ready_to_submit", "to": "failed" },
+    { "from": "ready_to_submit", "to": "cancelled" },
+    { "from": "pending", "to": "executing" },
+    { "from": "pending", "to": "failed" },
+    { "from": "pending", "to": "cancelled" },
+    { "from": "executing", "to": "settled" },
+    { "from": "executing", "to": "failed" },
+    { "from": "executing", "to": "reconciliation_required" },
+    { "from": "failed", "to": "validating" },
+    { "from": "failed", "to": "proof_pending" },
+    { "from": "failed", "to": "cancelled" },
+    { "from": "reconciliation_required", "to": "settled" },
+    { "from": "reconciliation_required", "to": "failed" }
+  ],
+  "blocked_transitions": [
+    { "rule": "any transition into draft", "outcome": "rejected" },
+    { "rule": "settled -> any", "outcome": "rejected (terminal)" },
+    { "rule": "cancelled -> any", "outcome": "rejected (terminal)" },
+    { "rule": "non-adjacent transitions (e.g. pending -> settled)", "outcome": "rejected" },
+    { "rule": "transition without company admin authorization", "outcome": "rejected" }
+  ],
+  "invalid_transition_error": "Invalid payroll state transition",
+  "enforcement_entry_point": "contracts/payroll/src/lib.rs::is_allowed_payroll_state_transition_internal",
+  "operations_hook": "contracts/payroll/src/lib.rs::transition_payroll_run_state"
+}

--- a/tests/settlement/Cargo.toml
+++ b/tests/settlement/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "settlement_state_tests"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["lib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+payroll = { path = "../../contracts/payroll" }
+proof_verifier = { path = "../../contracts/proof_verifier" }
+salary_commitment = { path = "../../contracts/salary_commitment" }
+token = { path = "../../contracts/token" }
+# Bring in pause_manager with its `contract` feature so feature unification
+# builds it in the configuration its source expects (the no-default-features
+# lib path fails to compile against the current SDK). This is purely a test
+# harness concern; it does not change any contract behavior.
+pause_manager = { path = "../../contracts/pause_manager" }

--- a/tests/settlement/src/common.rs
+++ b/tests/settlement/src/common.rs
@@ -1,0 +1,138 @@
+//! Shared helpers for settlement state transition tests.
+//!
+//! Mirrors the setup used by the payroll contract's own unit tests so the
+//! settlement suite exercises the real, fully wired contract stack.
+
+#![allow(dead_code)]
+
+use payroll::{Payroll, PayrollClient};
+use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
+use salary_commitment::{SalaryCommitmentContract, SalaryCommitmentContractClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, Vec};
+use token::{Token, TokenClient};
+
+/// Standard single-employee payment batch for preparing a run.
+pub fn mock_proof(env: &Env) -> BytesN<256> {
+    BytesN::from_array(env, &[0u8; 256])
+}
+
+/// Unique 32-byte run nonce derived from a seed.
+pub fn test_nonce(env: &Env, seed: u8) -> BytesN<32> {
+    let mut arr = [0u8; 32];
+    arr[0] = seed;
+    BytesN::from_array(env, &arr)
+}
+
+/// Mock Groth16 verification key accepted by `ProofVerifier` in tests.
+pub fn mock_vk(env: &Env) -> VerificationKey {
+    VerificationKey {
+        alpha: BytesN::from_array(env, &[0u8; 64]),
+        beta: BytesN::from_array(env, &[0u8; 128]),
+        gamma: BytesN::from_array(env, &[0u8; 128]),
+        delta: BytesN::from_array(env, &[0u8; 128]),
+        ic: Vec::from_array(
+            env,
+            [
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+            ],
+        ),
+    }
+}
+
+/// A fully wired payroll environment plus the roles the tests need.
+pub struct Setup {
+    pub env: Env,
+    pub payroll: PayrollClient<'static>,
+    pub admin: Address,
+    pub treasury: Address,
+    pub treasury_owner: Address,
+    pub employee: Address,
+}
+
+impl Setup {
+    pub fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let verifier_id = env.register_contract(None, ProofVerifier);
+        let verifier_client = ProofVerifierClient::new(&env, &verifier_id);
+        let verifier_admin = Address::generate(&env);
+        verifier_client.init_verifier_admin(&verifier_admin);
+        verifier_client.initialize_verifier(&mock_vk(&env));
+
+        let commitment_id = env.register_contract(None, SalaryCommitmentContract);
+        let commitment_client = SalaryCommitmentContractClient::new(&env, &commitment_id);
+        let commitment_admin = Address::generate(&env);
+        commitment_client.init_commitment_admin(&commitment_admin);
+
+        let token_id = env.register_contract(None, Token);
+        let token_client = TokenClient::new(&env, &token_id);
+
+        let payroll_id = env.register_contract(None, Payroll);
+        let payroll = PayrollClient::new(&env, &payroll_id);
+
+        let treasury = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let treasury_owner = Address::generate(&env);
+
+        token_client.mint(&treasury, &1_000_000i128);
+        payroll.initialize(
+            &admin,
+            &token_id,
+            &verifier_id,
+            &commitment_id,
+            &treasury,
+            &treasury_owner,
+        );
+
+        commitment_client.set_payroll_operator(&payroll_id);
+
+        let employee = Address::generate(&env);
+        commitment_client.store_commitment(&employee, &BytesN::from_array(&env, &[0u8; 32]));
+
+        // SAFETY: all clients borrow `env`, which lives for the lifetime of
+        // `Setup`. The transmute keeps the API ergonomic for test code.
+        let payroll = unsafe { extend_client_lifetime(payroll) };
+
+        Self {
+            env,
+            payroll,
+            admin,
+            treasury,
+            treasury_owner,
+            employee,
+        }
+    }
+
+    /// Single-employee payment batch used to prepare a payroll run.
+    pub fn single_payment_batch(&self, amount: i128) -> (Vec<BytesN<256>>, Vec<i128>, Vec<Address>) {
+        let mut proofs = Vec::new(&self.env);
+        proofs.push_back(mock_proof(&self.env));
+        let mut amounts = Vec::new(&self.env);
+        amounts.push_back(amount);
+        let mut employees = Vec::new(&self.env);
+        employees.push_back(self.employee.clone());
+        (proofs, amounts, employees)
+    }
+
+    /// Prepare a payroll run; it lands in the `Submitted` (`pending`) state.
+    pub fn prepare_run(&self, seed: u8) -> u64 {
+        let (proofs, amounts, employees) = self.single_payment_batch(1000);
+        self.payroll.prepare_payroll_run(
+            &proofs,
+            &amounts,
+            &employees,
+            &1000,
+            &test_nonce(&self.env, seed),
+            &None,
+        )
+    }
+}
+
+unsafe fn extend_client_lifetime<'a>(client: PayrollClient<'a>) -> PayrollClient<'static> {
+    std::mem::transmute::<PayrollClient<'a>, PayrollClient<'static>>(client)
+}

--- a/tests/settlement/src/lib.rs
+++ b/tests/settlement/src/lib.rs
@@ -1,0 +1,35 @@
+//! # Settlement State Transition Tests (issue #254)
+//!
+//! Verifies the canonical payroll **settlement** lifecycle enforced by
+//! `contracts/payroll/src/lib.rs`. The contract models the lifecycle with the
+//! `PayrollRunState` enum and the `is_allowed_payroll_state_transition_internal`
+//! matrix; the high-level settlement phases requested in the issue map onto it
+//! as follows:
+//!
+//! | Settlement phase (issue #254) | `PayrollRunState` |
+//! | ----------------------------- | ---------------- |
+//! | `pending`                     | `Submitted`      |
+//! | `executing`                   | `Confirming`    |
+//! | `settled`                     | `Completed`     |
+//! | `failed`                      | `Failed`        |
+//! | `cancelled`                   | `Cancelled`     |
+//!
+//! ## Structure
+//!
+//! - [`common`] — Shared test environment that wires the payroll contract
+//!   (verifier, commitment, token) and prepares a run in `Submitted`.
+//!
+//! - [`settlement_transitions`] — The allowed/blocked transition matrix:
+//!   every valid transition, predictably rejected invalid transitions,
+//!   terminal/immutable states, retryability, and authorization.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo test -p settlement_state_tests
+//! ```
+
+#[cfg(test)]
+mod common;
+#[cfg(test)]
+mod settlement_transitions;

--- a/tests/settlement/src/settlement_transitions.rs
+++ b/tests/settlement/src/settlement_transitions.rs
@@ -1,0 +1,367 @@
+//! Settlement state transition matrix tests (issue #254).
+//!
+//! The contract's canonical settlement lifecycle is the `PayrollRunState`
+//! machine in `contracts/payroll/src/lib.rs`, enforced by
+//! `is_allowed_payroll_state_transition_internal` and the admin-only
+//! `transition_payroll_run_state` hook. These tests pin down every allowed
+//! transition, prove invalid transitions are rejected predictably, and verify
+//! the terminal / retryable semantics plus authorization.
+//!
+//! High-level settlement phases (issue #254) map to concrete states as:
+//! `pending`→`Submitted`, `executing`→`Confirming`, `settled`→`Completed`,
+//! `failed`→`Failed`, `cancelled`→`Cancelled`.
+
+use crate::common::Setup;
+use payroll::PayrollRunState;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+/// Canonical set of allowed transitions, mirroring
+/// `is_allowed_payroll_state_transition_internal`. Used as the oracle for the
+/// matrix test so the contract cannot silently drift from the documented rules.
+fn expected_allowed(from: PayrollRunState, to: PayrollRunState) -> bool {
+    use PayrollRunState::*;
+    match from {
+        Draft => matches!(to, Validating | Cancelled),
+        Validating => matches!(to, ProofPending | Failed | Cancelled),
+        ProofPending => matches!(to, ReadyToSubmit | Failed | Cancelled),
+        ReadyToSubmit => matches!(to, Submitted | Failed | Cancelled),
+        Submitted => matches!(to, Confirming | Failed | Cancelled),
+        Confirming => matches!(to, Completed | Failed | ReconciliationRequired),
+        Failed => matches!(to, Validating | ProofPending | Cancelled),
+        ReconciliationRequired => matches!(to, Completed | Failed),
+        Completed | Cancelled => false,
+    }
+}
+
+/// Drive a freshly prepared run (starts in `Submitted`) to `target` via the
+/// shortest chain of allowed transitions. `Draft` is unreachable from
+/// `Submitted` and is intentionally excluded.
+fn drive_to(setup: &Setup, run_id: u64, target: PayrollRunState) {
+    use PayrollRunState::*;
+    let path: &[PayrollRunState] = match target {
+        Submitted => &[],
+        Confirming => &[Confirming],
+        Failed => &[Failed],
+        Cancelled => &[Cancelled],
+        ReconciliationRequired => &[Confirming, ReconciliationRequired],
+        Completed => &[Confirming, Completed],
+        Validating => &[Failed, Validating],
+        ProofPending => &[Failed, Validating, ProofPending],
+        ReadyToSubmit => &[Failed, Validating, ProofPending, ReadyToSubmit],
+        Draft => &[],
+    };
+    for step in path {
+        setup
+            .payroll
+            .transition_payroll_run_state(&setup.admin, &run_id, step);
+    }
+    assert_eq!(
+        setup.payroll.get_payroll_run_state(&run_id),
+        target,
+        "drive_to should land the run in the target state"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Matrix oracle — every valid/invalid transition
+// ---------------------------------------------------------------------------
+
+/// The contract's transition matrix must exactly match the documented rules
+/// for all 10 × 10 ordered pairs.
+#[test]
+fn transition_matrix_matches_documented_rules() {
+    use PayrollRunState::*;
+    let _env = Env::default();
+    let setup = Setup::new();
+
+    let states = [
+        Draft,
+        Validating,
+        ProofPending,
+        ReadyToSubmit,
+        Submitted,
+        Confirming,
+        Completed,
+        Failed,
+        Cancelled,
+        ReconciliationRequired,
+    ];
+
+    for &from in &states {
+        for &to in &states {
+            let actual = setup
+                .payroll
+                .is_state_transition_allowed(&from, &to);
+            assert_eq!(
+                actual,
+                expected_allowed(from, to),
+                "matrix mismatch for {:?} -> {:?}",
+                from,
+                to
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Valid transitions apply on-chain
+// ---------------------------------------------------------------------------
+
+/// `pending` (`Submitted`) → `executing` (`Confirming`) is an allowed
+/// settlement transition and is applied.
+#[test]
+fn pending_to_executing_is_applied() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(1);
+
+    setup
+        .payroll
+        .transition_payroll_run_state(&setup.admin, &run_id, &PayrollRunState::Confirming);
+
+    assert_eq!(
+        setup.payroll.get_payroll_run_state(&run_id),
+        PayrollRunState::Confirming
+    );
+}
+
+/// `executing` (`Confirming`) → `settled` (`Completed`) finalizes settlement.
+#[test]
+fn executing_to_settled_is_applied() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(2);
+    drive_to(&setup, run_id, PayrollRunState::Confirming);
+
+    setup
+        .payroll
+        .transition_payroll_run_state(&setup.admin, &run_id, &PayrollRunState::Completed);
+
+    assert_eq!(
+        setup.payroll.get_payroll_run_state(&run_id),
+        PayrollRunState::Completed
+    );
+}
+
+/// `executing` (`Confirming`) → `failed` (`Failed`) halts settlement and keeps
+/// the run retryable.
+#[test]
+fn executing_to_failed_is_applied() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(3);
+    drive_to(&setup, run_id, PayrollRunState::Confirming);
+
+    setup
+        .payroll
+        .transition_payroll_run_state(&setup.admin, &run_id, &PayrollRunState::Failed);
+
+    assert_eq!(
+        setup.payroll.get_payroll_run_state(&run_id),
+        PayrollRunState::Failed
+    );
+    assert!(setup.payroll.is_payroll_state_retryable(&PayrollRunState::Failed));
+}
+
+/// `pending` (`Submitted`) → `cancelled` (`Cancelled`) is allowed; the run is
+/// then terminal.
+#[test]
+fn pending_to_cancelled_is_applied() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(4);
+
+    setup
+        .payroll
+        .transition_payroll_run_state(&setup.admin, &run_id, &PayrollRunState::Cancelled);
+
+    assert_eq!(
+        setup.payroll.get_payroll_run_state(&run_id),
+        PayrollRunState::Cancelled
+    );
+}
+
+/// `failed` (`Failed`) → `pending` (`Validating`, retry) re-opens settlement.
+#[test]
+fn failed_to_retry_is_applied() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(5);
+    drive_to(&setup, run_id, PayrollRunState::Failed);
+
+    setup
+        .payroll
+        .transition_payroll_run_state(&setup.admin, &run_id, &PayrollRunState::Validating);
+
+    assert_eq!(
+        setup.payroll.get_payroll_run_state(&run_id),
+        PayrollRunState::Validating
+    );
+}
+
+/// `executing` (`Confirming`) → `ReconciliationRequired` is the settlement
+/// review path; from there `settled` (`Completed`) closes it.
+#[test]
+fn reconciliation_then_settled_is_applied() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(6);
+    drive_to(&setup, run_id, PayrollRunState::ReconciliationRequired);
+
+    setup
+        .payroll
+        .transition_payroll_run_state(&setup.admin, &run_id, &PayrollRunState::Completed);
+
+    assert_eq!(
+        setup.payroll.get_payroll_run_state(&run_id),
+        PayrollRunState::Completed
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Invalid transitions fail predictably
+// ---------------------------------------------------------------------------
+
+/// Skipping straight from `pending` to `settled` is not allowed and must
+/// panic with the canonical message.
+#[test]
+fn invalid_pending_to_settled_is_rejected() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(7);
+
+    let result = setup.payroll.try_transition_payroll_run_state(
+        &setup.admin,
+        &run_id,
+        &PayrollRunState::Completed,
+    );
+
+    assert!(result.is_err(), "pending -> settled is not a valid transition");
+}
+
+/// `failed` cannot jump to `settled` without going through reconciliation.
+#[test]
+fn invalid_failed_to_settled_is_rejected() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(8);
+    drive_to(&setup, run_id, PayrollRunState::Failed);
+
+    let result = setup.payroll.try_transition_payroll_run_state(
+        &setup.admin,
+        &run_id,
+        &PayrollRunState::Completed,
+    );
+
+    assert!(result.is_err(), "failed -> settled skips required reconciliation");
+}
+
+/// A terminal state accepts no further transitions: `settled` (`Completed`)
+/// rejects every attempted move.
+#[test]
+fn settled_is_terminal_and_rejects_all_transitions() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(9);
+    drive_to(&setup, run_id, PayrollRunState::Completed);
+
+    for next in [
+        PayrollRunState::Confirming,
+        PayrollRunState::Failed,
+        PayrollRunState::Cancelled,
+        PayrollRunState::ReconciliationRequired,
+        PayrollRunState::Submitted,
+    ] {
+        let result = setup
+            .payroll
+            .try_transition_payroll_run_state(&setup.admin, &run_id, &next);
+        assert!(
+            result.is_err(),
+            "settled (Completed) must reject transition to {:?}",
+            next
+        );
+    }
+    assert!(setup
+        .payroll
+        .is_payroll_state_terminal(&PayrollRunState::Completed));
+}
+
+/// `cancelled` is terminal and rejects every attempted transition.
+#[test]
+fn cancelled_is_terminal_and_rejects_all_transitions() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(10);
+    drive_to(&setup, run_id, PayrollRunState::Cancelled);
+
+    for next in [
+        PayrollRunState::Submitted,
+        PayrollRunState::Confirming,
+        PayrollRunState::Failed,
+        PayrollRunState::Validating,
+    ] {
+        let result = setup
+            .payroll
+            .try_transition_payroll_run_state(&setup.admin, &run_id, &next);
+        assert!(
+            result.is_err(),
+            "cancelled (Cancelled) must reject transition to {:?}",
+            next
+        );
+    }
+    assert!(setup
+        .payroll
+        .is_payroll_state_terminal(&PayrollRunState::Cancelled));
+}
+
+// ---------------------------------------------------------------------------
+// Authorization
+// ---------------------------------------------------------------------------
+
+/// Only the company admin may drive settlement state transitions.
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn non_admin_cannot_transition_settlement_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(11);
+
+    let attacker = Address::generate(&env);
+
+    setup.payroll.transition_payroll_run_state(
+        &attacker,
+        &run_id,
+        &PayrollRunState::Confirming,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle end-to-end
+// ---------------------------------------------------------------------------
+
+/// A prepared run starts in `pending` (`Submitted`) and settling it reaches
+/// `settled` (`Completed`).
+#[test]
+fn prepare_starts_pending_settlement() {
+    let setup = Setup::new();
+    let run_id = setup.prepare_run(12);
+
+    assert_eq!(
+        setup.payroll.get_payroll_run_state(&run_id),
+        PayrollRunState::Submitted
+    );
+}
+
+/// `failed` is the only retryable settlement state; `settled`/`cancelled` are
+/// not.
+#[test]
+fn only_failed_state_is_retryable() {
+    let _env = Env::default();
+    let setup = Setup::new();
+
+    assert!(setup
+        .payroll
+        .is_payroll_state_retryable(&PayrollRunState::Failed));
+    assert!(!setup
+        .payroll
+        .is_payroll_state_retryable(&PayrollRunState::Completed));
+    assert!(!setup
+        .payroll
+        .is_payroll_state_retryable(&PayrollRunState::Cancelled));
+    assert!(!setup
+        .payroll
+        .is_payroll_state_retryable(&PayrollRunState::Submitted));
+}


### PR DESCRIPTION
## Summary
Adds a dedicated `tests/settlement` crate that pins down the **settlement state machine** defined by `PayrollRunState` / `is_allowed_payroll_state_transition_internal` in `contracts/payroll/src/lib.rs`.

- **Full transition-matrix oracle**: a 10×10 grid test proving every allowed transition matches the contract's `is_allowed_payroll_state_transition_internal` rules, and every disallowed one is rejected predictably (no silent drift from the documented matrix).
- **Terminal / retryable semantics**: `is_payroll_state_terminal` and `is_payroll_state_retryable` are verified — only `Failed` is retryable; `Completed`/`Cancelled` are terminal and immutable.
- **Authorization**: `transition_payroll_run_state` is admin-only; a non-admin call panics with `Unauthorized`.
- **End-to-end lifecycle**: prepared run starts in `pending` (`Submitted`) and settling reaches `settled` (`Completed`).

Also adds `docs/settlement-state-machine.md` and `fixtures/state-machine/settlement-state-machine.json` documenting the settlement phase → concrete state mapping (`pending`→`Submitted`, `executing`→`Confirming`, `settled`→`Completed`, `failed`→`Failed`, `cancelled`→`Cancelled`).

This supersedes the previously opened PR #324 (which targeted `main`; the repo requires PRs against `dev`).

## Note on CI
The upstream workspace currently fails `cargo clippy --workspace --all-targets -D warnings` due to **unrelated** pre-existing breakage (`audit_module` is missing the `initialize` method required by `tests/migrations`). That is out of scope for this issue; this PR keeps the `settlement_state_tests` crate clippy-clean and all 14 of its tests passing.

Closes #254