### PR TITLE
Add employee status transition tests (issue #249)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "employee_status_tests"
+version = "0.1.0"
+dependencies = [
+ "payment_executor",
+ "payroll_registry",
+ "proof_verifier",
+ "salary_commitment",
+ "soroban-sdk",
+ "token",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "tests/storage",
     "tests/access-control",
     "tests/events",
+    "tests/employees",
 ]
 exclude = ["fuzz"]
 

--- a/contracts/payment_executor/src/lib.rs
+++ b/contracts/payment_executor/src/lib.rs
@@ -67,6 +67,12 @@ pub enum PaymentError {
     ProofExpired = 7,
     /// Empty payroll batches are rejected to avoid silent no-op execution.
     EmptyBatch = 8,
+    /// The employee is not eligible for payment (issue #249).
+    ///
+    /// Payroll execution consults `payroll_registry::is_eligible`, which is
+    /// `true` only for registered employees whose status is `Active`.
+    /// Inactive, incomplete, or removed employees must never be paid.
+    EmployeeIneligible = 9,
 }
 
 /// Contract addresses for dependencies
@@ -388,6 +394,14 @@ impl PaymentExecutor {
         let commitment = commitment_client.get_commitment(&employee).commitment;
         let registry = PayrollRegistryClient::new(&env, &addresses.registry);
         let company: CompanyInfo = registry.get_company(&company_id);
+
+        // Issue #249: payroll execution must respect employee status
+        // transitions. Only registered employees with `Active` status are
+        // eligible; inactive, incomplete, or removed employees are blocked
+        // before any proof verification or transfer takes place.
+        if !registry.is_eligible(&company_id, &employee) {
+            return Err(PaymentError::EmployeeIneligible);
+        }
 
         // Ensure only HR admin for this company can trigger payroll and treasury authorizes payment.
         company.admin.require_auth();

--- a/contracts/payroll_registry/src/lib.rs
+++ b/contracts/payroll_registry/src/lib.rs
@@ -389,7 +389,14 @@ impl PayrollRegistryTrait for PayrollRegistry {
         let emp = employee.clone();
         env.storage()
             .persistent()
-            .remove(&DataKey::Employee(company_id, emp));
+            .remove(&DataKey::Employee(company_id, emp.clone()));
+
+        // Issue #249: removal must also clear the eligibility status so that
+        // no stale status survives for an employee that no longer exists.
+        // Removed employees read back as `Incomplete` and are never eligible.
+        env.storage()
+            .persistent()
+            .remove(&DataKey::EmpStatus(company_id, emp));
 
         payroll_events::emit_employee_removed(&env, company_id, employee);
     }

--- a/docs/employees.md
+++ b/docs/employees.md
@@ -1,0 +1,82 @@
+# Employee Status Lifecycle
+
+Issue #249 documents the canonical employee status lifecycle that contracts,
+SDKs, and dashboards must mirror. The contract source of truth is
+`EmployeeStatus` in `contracts/payroll_registry/src/lib.rs`; the machine-readable
+mirror is `fixtures/state-machine/employee-status-machine.json`.
+
+## Canonical States
+
+| State | Contract variant | Eligible for payroll | Semantics |
+| --- | --- | --- | --- |
+| `active` | `Active` (ordinal 0) | Yes | Commitment registered and record complete; included in payroll runs. |
+| `inactive` | `Inactive` (ordinal 1) | No | Temporarily ineligible (on leave, suspended, terminated pending off-chain action). |
+| `incomplete` | `Incomplete` (ordinal 2) | No | Missing required registration data; never eligible until corrected and marked `active`. |
+| *removed* | *(record deleted)* | No | Terminal. The commitment and status entries are erased; reads fall back to `incomplete`. |
+
+New employees added via `add_employee` / `add_employee_by_wallet` start in
+`active`. Addresses with no registry entry also read as ineligible.
+
+## Allowed Transitions
+
+All transitions are initiated by the company admin via `set_employee_status`
+and require the company admin's authorization. Each accepted transition emits
+a lifecycle event carrying `(previous_status, new_status, ledger_sequence, timestamp)`.
+
+| From | To | Event | User-visible meaning |
+| --- | --- | --- | --- |
+| `active` | `inactive` | `EmployeeDeactivated` | Suspend an employee (leave of absence, suspension). |
+| `inactive` | `active` | `EmployeeReactivated` | Reactivate after suspension or return from leave. |
+| `active` | `incomplete` | `EmployeeStatusUpdated` | Flag a live record that lost required data. |
+| `incomplete` | `active` | `EmployeeStatusUpdated` | Record corrected; employee re-enters payroll. |
+| `inactive` | `incomplete` | `EmployeeStatusUpdated` | Escalate a suspension to a data-quality hold. |
+| `incomplete` | `inactive` | `EmployeeStatusUpdated` | Downgrade a data-quality hold to a plain suspension. |
+
+Writing the already-current status is an idempotent no-op: storage keeps its
+value and **no event is emitted**.
+
+## Blocked Transitions
+
+| Operation | Outcome |
+| --- | --- |
+| Status change without the company admin's authorization | Rejected (`require_auth` fails). |
+| Status change for an unregistered employee | Rejected — panics with `Employee not found`. |
+| Status change under an unknown company | Rejected — panics with `Company not found`. |
+| Any status change after removal | Rejected — removal is terminal; re-add the employee instead. |
+
+Removal itself (`remove_employee`) hard-deletes both the commitment
+(`DataKey::Employee`) and the eligibility entry (`DataKey::EmpStatus`) and
+emits `EmployeeRemoved`. A removed address reads back as `Incomplete` and is
+permanently ineligible until explicitly re-added, which starts a fresh
+`active` lifecycle.
+
+## Payroll Enforcement
+
+`payment_executor::execute_payment` (and therefore `execute_batch_payroll`)
+consults `payroll_registry::is_eligible` before verifying proofs or moving
+funds:
+
+* **Eligible** — registered and `Active`: payment proceeds.
+* **Ineligible** — everything else (`Inactive`, `Incomplete`, removed, or
+  never registered): payment aborts with `PaymentError::EmployeeIneligible`
+  before any token transfer, so no funds can reach a blocked employee.
+
+For batch execution this means an ineligible entry rejects the run with
+`PaymentError::EmployeeIneligible`; entries processed before the rejection
+point follow normal per-payment semantics.
+
+## Reference Implementation Tests
+
+The behaviour on this page is pinned by the integration suite in
+`tests/employees/`:
+
+| Suite | Coverage |
+| --- | --- |
+| `status_transitions.rs` | All six allowed transitions, idempotent same-status writes, unauthorized calls, unknown company/employee rejections, removal semantics, lifecycle event payloads. |
+| `payroll_eligibility.rs` | Active employees are paid; inactive, incomplete, removed, and unregistered addresses are blocked with no transfer; reactivation and record correction restore payability; batches reject ineligible entries. |
+
+Run them with:
+
+```bash
+cargo test -p employee_status_tests
+```

--- a/fixtures/state-machine/employee-status-machine.json
+++ b/fixtures/state-machine/employee-status-machine.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "issue": 249,
+  "source": "contracts/payroll_registry/src/lib.rs::EmployeeStatus",
+  "documentation": "docs/employees.md",
+  "states": [
+    {
+      "name": "active",
+      "contract_variant": "Active",
+      "ordinal": 0,
+      "payroll_eligible": true,
+      "user_visible": true,
+      "description": "Commitment registered and record complete; included in payroll runs."
+    },
+    {
+      "name": "inactive",
+      "contract_variant": "Inactive",
+      "ordinal": 1,
+      "payroll_eligible": false,
+      "user_visible": true,
+      "description": "Temporarily ineligible (on leave, suspended, terminated pending off-chain action)."
+    },
+    {
+      "name": "incomplete",
+      "contract_variant": "Incomplete",
+      "ordinal": 2,
+      "payroll_eligible": false,
+      "user_visible": true,
+      "description": "Missing required registration data; never eligible until corrected and marked active."
+    },
+    {
+      "name": "removed",
+      "contract_variant": null,
+      "ordinal": null,
+      "payroll_eligible": false,
+      "user_visible": true,
+      "terminal": true,
+      "description": "Terminal state. Commitment and status entries erased; reads fall back to incomplete."
+    }
+  ],
+  "allowed_transitions": [
+    { "from": "active", "to": "inactive", "event": "EmployeeDeactivated" },
+    { "from": "inactive", "to": "active", "event": "EmployeeReactivated" },
+    { "from": "active", "to": "incomplete", "event": "EmployeeStatusUpdated" },
+    { "from": "incomplete", "to": "active", "event": "EmployeeStatusUpdated" },
+    { "from": "inactive", "to": "incomplete", "event": "EmployeeStatusUpdated" },
+    { "from": "incomplete", "to": "inactive", "event": "EmployeeStatusUpdated" }
+  ],
+  "no_op_transitions": [
+    { "from": "active", "to": "active" },
+    { "from": "inactive", "to": "inactive" },
+    { "from": "incomplete", "to": "incomplete" }
+  ],
+  "blocked_operations": [
+    { "operation": "set_employee_status without company admin authorization", "outcome": "rejected" },
+    { "operation": "set_employee_status for unregistered employee", "outcome": "rejected: Employee not found" },
+    { "operation": "set_employee_status under unknown company", "outcome": "rejected: Company not found" },
+    { "operation": "any status change after removal", "outcome": "rejected; re-add the employee instead" }
+  ],
+  "removal_event": "EmployeeRemoved",
+  "payroll_enforcement": {
+    "entry_point": "contracts/payment_executor/src/lib.rs::execute_payment",
+    "eligibility_check": "payroll_registry::is_eligible",
+    "ineligible_error": "PaymentError::EmployeeIneligible"
+  }
+}

--- a/tests/employees/Cargo.toml
+++ b/tests/employees/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "employee_status_tests"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["lib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+payroll_registry = { path = "../../contracts/payroll_registry" }
+payment_executor = { path = "../../contracts/payment_executor" }
+salary_commitment = { path = "../../contracts/salary_commitment" }
+proof_verifier = { path = "../../contracts/proof_verifier" }
+token = { path = "../../contracts/token" }

--- a/tests/employees/src/common.rs
+++ b/tests/employees/src/common.rs
@@ -1,0 +1,151 @@
+//! Shared helpers for employee status transition tests.
+//!
+//! Wires the full contract stack the way `payment_executor` expects
+//! (registry, salary commitment, proof verifier, token) and provides
+//! small seeding helpers so each test only describes what it varies.
+
+#![allow(dead_code)]
+
+use payment_executor::{ContractAddresses, PaymentExecutor, PaymentExecutorClient};
+use payroll_registry::{EmployeeStatus, PayrollRegistry, PayrollRegistryClient};
+use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
+use salary_commitment::{SalaryCommitmentContract, SalaryCommitmentContractClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, Vec};
+use token::{Token, TokenClient};
+
+/// Standard test payroll amount used by the eligibility tests.
+pub const PAYMENT_AMOUNT: i128 = 1_000;
+/// Treasury mint size that comfortably covers a single test payment.
+pub const TREASURY_FUNDING: i128 = 10_000;
+
+/// Deterministic 32-byte commitment derived from a seed byte.
+pub fn commitment(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+/// Mock Groth16 verification key accepted by `ProofVerifier`.
+///
+/// The verifier accepts zeroed keys in test mode, so payments can exercise
+/// the full execution path without real circuit artifacts.
+pub fn mock_vk(env: &Env) -> VerificationKey {
+    VerificationKey {
+        alpha: BytesN::from_array(env, &[0u8; 64]),
+        beta: BytesN::from_array(env, &[0u8; 128]),
+        gamma: BytesN::from_array(env, &[0u8; 128]),
+        delta: BytesN::from_array(env, &[0u8; 128]),
+        ic: Vec::from_array(
+            env,
+            [
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+            ],
+        ),
+    }
+}
+
+/// A fully wired contract environment.
+///
+/// Clients borrow from [`TestEnv::env`], so tests create them per scope:
+/// `PayrollRegistryClient::new(&t.env, &t.addresses.registry)`.
+pub struct TestEnv {
+    pub env: Env,
+    pub addresses: ContractAddresses,
+    pub executor_id: Address,
+}
+
+impl TestEnv {
+    /// Deploy and initialize every contract with mocked authentication.
+    pub fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let registry_id = env.register_contract(None, PayrollRegistry);
+        let commitment_id = env.register_contract(None, SalaryCommitmentContract);
+        let verifier_id = env.register_contract(None, ProofVerifier);
+        let token_id = env.register_contract(None, Token);
+        let executor_id = env.register_contract(None, PaymentExecutor);
+
+        let verifier = ProofVerifierClient::new(&env, &verifier_id);
+        verifier.init_verifier_admin(&Address::generate(&env));
+        verifier.initialize_verifier(&mock_vk(&env));
+
+        let commitment = SalaryCommitmentContractClient::new(&env, &commitment_id);
+        commitment.init_commitment_admin(&Address::generate(&env));
+
+        let addresses = ContractAddresses {
+            registry: registry_id,
+            commitment: commitment_id,
+            verifier: verifier_id,
+            token: token_id,
+        };
+
+        PaymentExecutorClient::new(&env, &executor_id).initialize(&addresses);
+
+        Self {
+            env,
+            addresses,
+            executor_id,
+        }
+    }
+
+    /// Register a company and fund its treasury.
+    ///
+    /// Returns `(company_id, admin, treasury)`.
+    pub fn register_company(&self) -> (u64, Address, Address) {
+        let admin = Address::generate(&self.env);
+        let treasury = Address::generate(&self.env);
+
+        let company_id = self.registry().register_company(&admin, &treasury);
+
+        self.token().mint(&treasury, &TREASURY_FUNDING);
+
+        (company_id, admin, treasury)
+    }
+
+    /// Add an employee whose salary commitment matches their registry entry
+    /// and whose status starts as [`EmployeeStatus::Active`].
+    pub fn add_active_employee(&self, company_id: u64, seed: u8) -> Address {
+        let employee = Address::generate(&self.env);
+        let commit = commitment(&self.env, seed);
+
+        self.commitment_store().store_commitment(&employee, &commit);
+        self.registry().add_employee(&company_id, &employee, &commit);
+
+        employee
+    }
+
+    /// Open payroll period 1 for the company.
+    pub fn open_period(&self, company_id: u64) {
+        self.executor().create_period(&company_id);
+    }
+
+    pub fn registry(&self) -> PayrollRegistryClient<'_> {
+        PayrollRegistryClient::new(&self.env, &self.addresses.registry)
+    }
+
+    pub fn commitment_store(&self) -> SalaryCommitmentContractClient<'_> {
+        SalaryCommitmentContractClient::new(&self.env, &self.addresses.commitment)
+    }
+
+    pub fn token(&self) -> TokenClient<'_> {
+        TokenClient::new(&self.env, &self.addresses.token)
+    }
+
+    pub fn executor(&self) -> PaymentExecutorClient<'_> {
+        PaymentExecutorClient::new(&self.env, &self.executor_id)
+    }
+
+    /// Set the employee status as the company admin would.
+    pub fn set_status(&self, company_id: u64, employee: &Address, status: EmployeeStatus) {
+        self.registry()
+            .set_employee_status(&company_id, employee, &status);
+    }
+}
+
+impl Default for TestEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/employees/src/lib.rs
+++ b/tests/employees/src/lib.rs
@@ -1,0 +1,30 @@
+//! # Employee Status Transition Tests (issue #249)
+//!
+//! Verifies the employee lifecycle enforced by `payroll_registry` and that
+//! payroll execution respects employee status.
+//!
+//! ## Structure
+//!
+//! - [`common`] — Shared test environment helpers (contract wiring, company
+//!   and employee seeding, payment executor plumbing).
+//!
+//! - [`status_transitions`] — The allowed/blocked status transition matrix:
+//!   every supported status change, idempotent no-ops, unauthorized calls,
+//!   unknown companies/employees, and removal semantics.
+//!
+//! - [`payroll_eligibility`] — End-to-end checks that `payment_executor`
+//!   pays only `Active` employees and blocks inactive, incomplete, removed,
+//!   or unregistered ones.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo test -p employee_status_tests
+//! ```
+
+#[cfg(test)]
+mod common;
+#[cfg(test)]
+mod payroll_eligibility;
+#[cfg(test)]
+mod status_transitions;

--- a/tests/employees/src/payroll_eligibility.rs
+++ b/tests/employees/src/payroll_eligibility.rs
@@ -1,0 +1,258 @@
+//! End-to-end checks that payroll execution respects employee status
+//! transitions (issue #249).
+//!
+//! `payment_executor::execute_payment` must consult the registry before
+//! moving funds: only registered employees whose status is `Active` are
+//! payable. Suspended (`Inactive`), flagged (`Incomplete`), removed, and
+//! never-registered employees are rejected with
+//! [`PaymentError::EmployeeIneligible`] and no token transfer takes place.
+//!
+//! [`PaymentError::EmployeeIneligible`]: payment_executor::PaymentError::EmployeeIneligible
+
+use crate::common::{commitment, TestEnv, PAYMENT_AMOUNT};
+use payment_executor::PaymentError;
+use payroll_registry::EmployeeStatus;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN};
+
+/// Distinct Groth16 placeholder proofs; the mock verifier accepts them all.
+struct Proofs {
+    a: BytesN<64>,
+    b: BytesN<128>,
+    c: BytesN<64>,
+    nullifier: BytesN<32>,
+}
+
+fn proofs(env: &soroban_sdk::Env, seed: u8) -> Proofs {
+    Proofs {
+        a: BytesN::from_array(env, &[seed; 64]),
+        b: BytesN::from_array(env, &[seed; 128]),
+        c: BytesN::from_array(env, &[seed.wrapping_add(1); 64]),
+        nullifier: BytesN::from_array(env, &[seed.wrapping_add(2); 32]),
+    }
+}
+
+/// Pay `employee` through the executor as the company admin.
+fn pay(t: &TestEnv, company_id: u64, employee: &Address, seed: u8) {
+    let p = proofs(&t.env, seed);
+    t.executor()
+        .execute_payment(
+            &company_id,
+            employee,
+            &PAYMENT_AMOUNT,
+            &p.a,
+            &p.b,
+            &p.c,
+            &p.nullifier,
+            &1u32,
+        );
+}
+
+/// Expect [`PaymentError::EmployeeIneligible`] from a payment attempt.
+fn expect_ineligible(t: &TestEnv, company_id: u64, employee: &Address, seed: u8) {
+    let p = proofs(&t.env, seed);
+    let result = t.executor().try_execute_payment(
+        &company_id,
+        employee,
+        &PAYMENT_AMOUNT,
+        &p.a,
+        &p.b,
+        &p.c,
+        &p.nullifier,
+        &1u32,
+    );
+
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        PaymentError::EmployeeIneligible,
+        "ineligible employees must be blocked from payroll"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+/// An Active employee is paid normally: funds move treasury → employee and
+/// the payment is recorded for the period.
+#[test]
+fn active_employee_is_paid() {
+    let t = TestEnv::new();
+    let (company_id, _admin, treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 20);
+    t.open_period(company_id);
+
+    pay(&t, company_id, &employee, 100);
+
+    assert_eq!(t.token().balance(&employee), PAYMENT_AMOUNT);
+    assert_eq!(
+        t.token().balance(&treasury),
+        crate::common::TREASURY_FUNDING - PAYMENT_AMOUNT
+    );
+    assert!(t.executor().is_paid(&employee, &1));
+}
+
+// ---------------------------------------------------------------------------
+// Blocked employees
+// ---------------------------------------------------------------------------
+
+/// Deactivating an employee blocks their payment: nothing transfers and the
+/// period shows no payment for them.
+#[test]
+fn inactive_employee_is_not_paid() {
+    let t = TestEnv::new();
+    let (company_id, _admin, treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 21);
+    t.open_period(company_id);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+
+    expect_ineligible(&t, company_id, &employee, 101);
+
+    assert_eq!(t.token().balance(&employee), 0);
+    assert_eq!(t.token().balance(&treasury), crate::common::TREASURY_FUNDING);
+    assert!(!t.executor().is_paid(&employee, &1));
+    assert_eq!(t.executor().get_total_paid(&company_id), 0);
+}
+
+/// Employees flagged `Incomplete` are blocked from payroll until their
+/// record is corrected.
+#[test]
+fn incomplete_employee_is_not_paid() {
+    let t = TestEnv::new();
+    let (company_id, _admin, treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 22);
+    t.open_period(company_id);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Incomplete);
+
+    expect_ineligible(&t, company_id, &employee, 102);
+
+    assert_eq!(t.token().balance(&employee), 0);
+    assert_eq!(t.token().balance(&treasury), crate::common::TREASURY_FUNDING);
+}
+
+/// Removed employees can never be paid, even though their salary
+/// commitment may have been re-registered by an indexer replay.
+#[test]
+fn removed_employee_is_not_paid() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 23);
+    t.open_period(company_id);
+
+    t.registry().remove_employee(&company_id, &employee);
+
+    expect_ineligible(&t, company_id, &employee, 103);
+    assert_eq!(t.token().balance(&employee), 0);
+}
+
+/// An address holding a stored commitment but absent from the registry has
+/// no eligibility either — registry membership gates payroll.
+#[test]
+fn unregistered_address_is_not_paid() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let outsider = Address::generate(&t.env);
+
+    // Commitment exists, but the registry has no record of this employee.
+    t.commitment_store()
+        .store_commitment(&outsider, &commitment(&t.env, 24));
+    t.open_period(company_id);
+
+    expect_ineligible(&t, company_id, &outsider, 104);
+    assert_eq!(t.token().balance(&outsider), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Reactivation restores payroll access
+// ---------------------------------------------------------------------------
+
+/// Suspend → attempt payment → reactivate → payment succeeds. A status
+/// round-trip fully restores payroll participation.
+#[test]
+fn reactivated_employee_is_paid_again() {
+    let t = TestEnv::new();
+    let (company_id, _admin, treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 25);
+    t.open_period(company_id);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+    expect_ineligible(&t, company_id, &employee, 105);
+    assert_eq!(t.token().balance(&employee), 0);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Active);
+    pay(&t, company_id, &employee, 106);
+
+    assert_eq!(t.token().balance(&employee), PAYMENT_AMOUNT);
+    assert_eq!(t.token().balance(&treasury), crate::common::TREASURY_FUNDING - PAYMENT_AMOUNT);
+    assert!(t.executor().is_paid(&employee, &1));
+}
+
+/// Correcting an `Incomplete` record back to `Active` also re-enables
+/// payment.
+#[test]
+fn corrected_incomplete_record_is_payable_again() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 26);
+    t.open_period(company_id);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Incomplete);
+    expect_ineligible(&t, company_id, &employee, 107);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Active);
+    pay(&t, company_id, &employee, 108);
+
+    assert_eq!(t.token().balance(&employee), PAYMENT_AMOUNT);
+}
+
+// ---------------------------------------------------------------------------
+// Batch execution
+// ---------------------------------------------------------------------------
+
+/// A batch containing an ineligible employee is rejected outright when the
+/// ineligible entry comes first: no employee in the batch is paid.
+#[test]
+fn batch_containing_inactive_employee_is_rejected() {
+    use soroban_sdk::Vec;
+
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let inactive_employee = t.add_active_employee(company_id, 27);
+    let active_employee = t.add_active_employee(company_id, 28);
+    t.open_period(company_id);
+
+    t.set_status(company_id, &inactive_employee, EmployeeStatus::Inactive);
+
+    let employees = Vec::from_array(
+        &t.env,
+        [inactive_employee.clone(), active_employee.clone()],
+    );
+    let amounts = Vec::from_array(&t.env, [PAYMENT_AMOUNT, PAYMENT_AMOUNT]);
+    let p0 = proofs(&t.env, 109);
+    let p1 = proofs(&t.env, 110);
+    let proofs_a = Vec::from_array(&t.env, [p0.a, p1.a]);
+    let proofs_b = Vec::from_array(&t.env, [p0.b, p1.b]);
+    let proofs_c = Vec::from_array(&t.env, [p0.c, p1.c]);
+    let nullifiers = Vec::from_array(&t.env, [p0.nullifier, p1.nullifier]);
+
+    let result = t.executor().try_execute_batch_payroll(
+        &company_id,
+        &employees,
+        &amounts,
+        &proofs_a,
+        &proofs_b,
+        &proofs_c,
+        &nullifiers,
+        &1u32,
+    );
+
+    assert_eq!(result.unwrap_err().unwrap(), PaymentError::EmployeeIneligible);
+
+    // Nobody in the batch received funds.
+    assert_eq!(t.token().balance(&inactive_employee), 0);
+    assert_eq!(t.token().balance(&active_employee), 0);
+    assert!(!t.executor().is_paid(&active_employee, &1));
+    assert_eq!(t.executor().get_total_paid(&company_id), 0);
+}

--- a/tests/employees/src/status_transitions.rs
+++ b/tests/employees/src/status_transitions.rs
@@ -1,0 +1,410 @@
+//! Employee status transition matrix tests (issue #249).
+//!
+//! The registry models three registration states — [`Active`],
+//! [`Inactive`], and [`Incomplete`] — plus hard removal. These tests pin
+//! down every allowed transition, prove invalid operations are rejected,
+//! and document the events emitted along the way.
+//!
+//! Allowed transitions (all initiated by the company admin via
+//! `set_employee_status`):
+//!
+//! | From        | To          | Event                  |
+//! | ----------- | ----------- | ---------------------- |
+//! | Active      | Inactive    | `EmployeeDeactivated`  |
+//! | Inactive    | Active      | `EmployeeReactivated`  |
+//! | Active      | Incomplete  | `EmployeeStatusUpdated`|
+//! | Incomplete  | Active      | `EmployeeStatusUpdated`|
+//! | Inactive    | Incomplete  | `EmployeeStatusUpdated`|
+//! | Incomplete  | Inactive    | `EmployeeStatusUpdated`|
+//!
+//! Blocked / rejected operations:
+//!
+//! * any status change for an unregistered employee (`Employee not found`)
+//! * any status change under an unknown company (`Company not found`)
+//! * same-status writes are silently ignored (no event, no storage churn)
+//! * calls that do not carry the company admin's authorization
+//! * status changes after removal (the record is gone)
+//!
+//! [`Active`]: payroll_registry::EmployeeStatus::Active
+//! [`Inactive`]: payroll_registry::EmployeeStatus::Inactive
+//! [`Incomplete`]: payroll_registry::EmployeeStatus::Incomplete
+
+use crate::common::{commitment, TestEnv};
+use payroll_registry::EmployeeStatus;
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{Address, IntoVal, Symbol, TryIntoVal};
+
+// ---------------------------------------------------------------------------
+// Allowed transitions
+// ---------------------------------------------------------------------------
+
+/// Active → Inactive suspends payroll eligibility while keeping the
+/// commitment registered.
+#[test]
+fn active_to_inactive_suspends_eligibility() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 1);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Inactive
+    );
+    assert!(!t.registry().is_eligible(&company_id, &employee));
+}
+
+/// Inactive → Active reactivates a suspended employee and restores full
+/// payroll eligibility without re-registering them.
+#[test]
+fn inactive_to_active_restores_eligibility() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 2);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+    t.set_status(company_id, &employee, EmployeeStatus::Active);
+
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Active
+    );
+    assert!(t.registry().is_eligible(&company_id, &employee));
+}
+
+/// Active → Incomplete flags a record that lost required data; the employee
+/// must stop being eligible immediately.
+#[test]
+fn active_to_incomplete_blocks_eligibility() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 3);
+    assert!(t.registry().is_eligible(&company_id, &employee));
+
+    t.set_status(company_id, &employee, EmployeeStatus::Incomplete);
+
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Incomplete
+    );
+    assert!(!t.registry().is_eligible(&company_id, &employee));
+}
+
+/// Incomplete → Active is the "record corrected" path back into payroll.
+#[test]
+fn incomplete_to_active_after_record_correction_is_allowed() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 4);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Incomplete);
+    assert!(!t.registry().is_eligible(&company_id, &employee));
+
+    t.set_status(company_id, &employee, EmployeeStatus::Active);
+
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Active
+    );
+    assert!(t.registry().is_eligible(&company_id, &employee));
+}
+
+/// Inactive → Incomplete lets an admin escalate a suspended record to an
+/// explicit data-quality hold; the employee stays ineligible.
+#[test]
+fn inactive_to_incomplete_stays_ineligible() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 5);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+    t.set_status(company_id, &employee, EmployeeStatus::Incomplete);
+
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Incomplete
+    );
+    assert!(!t.registry().is_eligible(&company_id, &employee));
+}
+
+/// Incomplete → Inactive downgrades a data-quality hold to a plain
+/// suspension; the employee remains ineligible either way.
+#[test]
+fn incomplete_to_inactive_stays_ineligible() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 6);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Incomplete);
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Inactive
+    );
+    assert!(!t.registry().is_eligible(&company_id, &employee));
+}
+
+/// Status changes never disturb the stored salary commitment.
+#[test]
+fn transitions_preserve_commitment() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 7);
+    let expected = commitment(&t.env, 7);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+    t.set_status(company_id, &employee, EmployeeStatus::Incomplete);
+
+    assert_eq!(
+        t.registry().get_commitment(&company_id, &employee),
+        expected
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rejected operations
+// ---------------------------------------------------------------------------
+
+/// Setting a status for an address that was never added is rejected.
+#[test]
+fn set_status_for_unregistered_employee_panics() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let stranger = Address::generate(&t.env);
+
+    let result = t
+        .registry()
+        .try_set_employee_status(&company_id, &stranger, &EmployeeStatus::Inactive);
+
+    assert!(result.is_err(), "unregistered employees have no status to change");
+}
+
+/// Status updates under a company id that does not exist are rejected.
+#[test]
+fn set_status_under_unknown_company_panics() {
+    let t = TestEnv::new();
+    let (_id, _admin, _treasury) = t.register_company();
+    let employee = Address::generate(&t.env);
+
+    let result = t
+        .registry()
+        .try_set_employee_status(&999u64, &employee, &EmployeeStatus::Inactive);
+
+    assert!(result.is_err());
+}
+
+/// Writing the already-current status is a silent no-op: storage keeps its
+/// value and no lifecycle event is emitted.
+#[test]
+fn same_status_write_is_an_idempotent_no_op() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 8);
+
+    let before = t.env.events().all().len();
+
+    t.set_status(company_id, &employee, EmployeeStatus::Active);
+
+    assert_eq!(
+        t.env.events().all().len(),
+        before,
+        "no-op transitions must not emit lifecycle events"
+    );
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Active
+    );
+}
+
+/// A non-admin authorization is rejected by the company admin check.
+///
+/// The mock auth signs the call as `attacker`, so the contract's
+/// `require_auth` against the real admin must fail.
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn set_status_requires_the_company_admin_signature() {
+    use soroban_sdk::testutils::MockAuth;
+    use soroban_sdk::testutils::MockAuthInvoke;
+
+    let env = soroban_sdk::Env::default();
+    env.mock_all_auths();
+
+    let registry_id = env.register_contract(None, payroll_registry::PayrollRegistry);
+    let registry = payroll_registry::PayrollRegistryClient::new(&env, &registry_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let company_id = registry.register_company(&admin, &treasury);
+
+    let employee = Address::generate(&env);
+    registry.add_employee(&company_id, &employee, &commitment(&env, 9));
+
+    let attacker = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &registry_id,
+            fn_name: "set_employee_status",
+            args: (
+                company_id,
+                employee.clone(),
+                EmployeeStatus::Inactive,
+            )
+                .into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    registry.set_employee_status(&company_id, &employee, &EmployeeStatus::Inactive);
+}
+
+// ---------------------------------------------------------------------------
+// Removal behaviour
+// ---------------------------------------------------------------------------
+
+/// Removing an employee hard-deletes both the commitment and the eligibility
+/// status; the employee reads back as `Incomplete` and is never eligible.
+#[test]
+fn removal_clears_record_and_status() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 10);
+
+    // Deactivate first so a stale `Inactive` value would be observable if
+    // removal failed to clear it.
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+    t.registry().remove_employee(&company_id, &employee);
+
+    assert!(!t.registry().is_eligible(&company_id, &employee));
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Incomplete,
+        "removed employees must read back as Incomplete, not keep stale state"
+    );
+
+    let result = t.registry().try_get_commitment(&company_id, &employee);
+    assert!(result.is_err(), "commitment must be gone after removal");
+}
+
+/// Any status change after removal is rejected: removed is terminal.
+#[test]
+fn set_status_after_removal_panics() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 11);
+
+    t.registry().remove_employee(&company_id, &employee);
+
+    let result = t
+        .registry()
+        .try_set_employee_status(&company_id, &employee, &EmployeeStatus::Active);
+
+    assert!(result.is_err(), "removed employees cannot be reactivated in place");
+}
+
+/// Re-adding a previously removed employee starts a clean lifecycle:
+/// fresh `Active` status and restored eligibility.
+#[test]
+fn readdition_after_removal_starts_fresh_as_active() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 12);
+
+    t.registry().remove_employee(&company_id, &employee);
+    assert!(!t.registry().is_eligible(&company_id, &employee));
+
+    let new_commitment = commitment(&t.env, 99);
+    t.commitment_store().store_commitment(&employee, &new_commitment);
+    t.registry()
+        .add_employee(&company_id, &employee, &new_commitment);
+
+    assert_eq!(
+        t.registry().get_employee_status(&company_id, &employee),
+        EmployeeStatus::Active
+    );
+    assert!(t.registry().is_eligible(&company_id, &employee));
+}
+
+/// Removal emits the `EmployeeRemoved` audit event.
+#[test]
+fn removal_emits_employee_removed_event() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 13);
+
+    let before = t.env.events().all().len();
+    t.registry().remove_employee(&company_id, &employee);
+    let after = t.env.events().all().len();
+    assert_eq!(after, before + 1);
+
+    let event = t.env.events().all().get(after - 1).unwrap();
+    let sym: Symbol = event.1.get(0).unwrap().try_into_val(&t.env).unwrap();
+    assert_eq!(sym, Symbol::new(&t.env, "EmployeeRemoved"));
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle event payloads
+// ---------------------------------------------------------------------------
+
+/// Deactivation emits `EmployeeDeactivated` carrying the previous and new
+/// status plus ledger metadata.
+#[test]
+fn deactivation_event_reports_previous_and_new_status() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 14);
+
+    let before = t.env.events().all().len();
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+    let event = t.env.events().all().get(before).unwrap();
+
+    let sym: Symbol = event.1.get(0).unwrap().try_into_val(&t.env).unwrap();
+    assert_eq!(sym, Symbol::new(&t.env, "EmployeeDeactivated"));
+
+    let data_tuple: (EmployeeStatus, EmployeeStatus, u32, u64) =
+        event.2.try_into_val(&t.env).unwrap();
+    assert_eq!(data_tuple.0, EmployeeStatus::Active);
+    assert_eq!(data_tuple.1, EmployeeStatus::Inactive);
+}
+
+/// Reactivation emits `EmployeeReactivated` carrying the previous and new
+/// status.
+#[test]
+fn reactivation_event_reports_previous_and_new_status() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 15);
+
+    t.set_status(company_id, &employee, EmployeeStatus::Inactive);
+
+    let before = t.env.events().all().len();
+    t.set_status(company_id, &employee, EmployeeStatus::Active);
+    let event = t.env.events().all().get(before).unwrap();
+
+    let sym: Symbol = event.1.get(0).unwrap().try_into_val(&t.env).unwrap();
+    assert_eq!(sym, Symbol::new(&t.env, "EmployeeReactivated"));
+
+    let data_tuple: (EmployeeStatus, EmployeeStatus, u32, u64) =
+        event.2.try_into_val(&t.env).unwrap();
+    assert_eq!(data_tuple.0, EmployeeStatus::Inactive);
+    assert_eq!(data_tuple.1, EmployeeStatus::Active);
+}
+
+/// Transitions into or out of `Incomplete` emit the generic
+/// `EmployeeStatusUpdated` event.
+#[test]
+fn incomplete_transition_emits_generic_status_updated_event() {
+    let t = TestEnv::new();
+    let (company_id, _admin, _treasury) = t.register_company();
+    let employee = t.add_active_employee(company_id, 16);
+
+    let before = t.env.events().all().len();
+    t.set_status(company_id, &employee, EmployeeStatus::Incomplete);
+    let event = t.env.events().all().get(before).unwrap();
+
+    let sym: Symbol = event.1.get(0).unwrap().try_into_val(&t.env).unwrap();
+    assert_eq!(sym, Symbol::new(&t.env, "EmployeeStatusUpdated"));
+}


### PR DESCRIPTION
## Summary
Adds a `tests/employees` crate that pins down the employee status lifecycle and its interaction with payroll execution, per issue #249.

- **Status transition matrix**: `status_transitions.rs` drives the documented `EmpStatus` machine (`Incomplete` → `Active` → `Inactive`/`Removed`, with the `Removed` terminal cleanup) and asserts the contract rejects illegal transitions.
- **Payroll eligibility gate**: `payroll_eligibility.rs` verifies that `payment_executor::execute_payment` / `execute_batch_payroll` block employees that are not `Active` (`EmployeeIneligible`), and that the registry `remove_employee` clears the stored status.
- **Contract changes** (minimal, required to make the behaviour observable/testable):
  - `payment_executor`: added `EmployeeIneligible` error and an `is_eligible` check before any transfer.
  - `payroll_registry`: `remove_employee` now clears `EmpStatus`.

Also adds `docs/employees.md` and `fixtures/state-machine/employee-status-machine.json`.

This supersedes the previously opened PR #322 (which targeted `main`; the repo requires PRs against `dev`).

## Note on CI
The upstream workspace currently fails `cargo clippy --workspace --all-targets -D warnings` due to **unrelated** pre-existing breakage (`audit_module` is missing the `initialize` method required by `tests/migrations`). That is out of scope for this issue; this PR keeps `employee_status_tests` clippy-clean with all 26 tests passing.

Closes #249