### PR TITLE
Add Soroban event schema snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event_schema_snapshots"
+version = "0.1.0"
+dependencies = [
+ "payroll_events",
+ "serde",
+ "serde_json",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "tests/storage",
     "tests/access-control",
     "tests/events",
+    "tests/event_schema",
 ]
 exclude = ["fuzz"]
 

--- a/tests/event_schema/Cargo.toml
+++ b/tests/event_schema/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "event_schema_snapshots"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["rlib"]
+doctest = false
+
+[dev-dependencies]
+payroll_events = { path = "../../contracts/events" }
+soroban-sdk = { workspace = true, features = ["testutils"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/tests/event_schema/fixtures/events/README.md
+++ b/tests/event_schema/fixtures/events/README.md
@@ -1,0 +1,80 @@
+# Event schema fixtures
+
+This directory pins the wire shape of every Soroban event emitted through
+`payroll_events` (`contracts/events/src/lib.rs`). Each file is a JSON map,
+keyed `"<contract-domain>.<event>"`, of the topics and payload fields that
+event is expected to publish:
+
+```json
+"payroll.deposit": {
+  "schema_version": 1,
+  "topics": [
+    { "type": "Symbol", "value": "payroll" },
+    { "type": "Symbol", "value": "deposit" }
+  ],
+  "data": [
+    { "name": "from", "type": "Address" },
+    { "name": "amount", "type": "i128" },
+    { "name": "deposit_id", "type": "BytesN<32>" }
+  ]
+}
+```
+
+- `topics` are positional. A `Symbol` topic records its exact `value`
+  because it *is* part of the contract (SDKs filter on it). A topic that
+  carries a per-invocation identifier (`Address`, `u64`, ...) only records
+  its `type`, since the value is naturally dynamic.
+- `data` is also positional — Soroban events don't carry field names on the
+  wire — so `name` here is documentation for the humans and tools consuming
+  the event; only `type` (and field order/count) is actually enforced.
+- `schema_version` is a per-event, repo-only counter. It is **not** part of
+  the on-chain payload; consumers key off event name plus shape. Bump it
+  whenever you deliberately change that event's topics or data, so a
+  changelog entry / consumer migration is easy to find in git blame.
+
+## How the tests use this
+
+`tests/event_schema/src/<domain>.rs` has one `#[test]` per contract domain.
+Each test:
+
+1. Calls the real `payroll_events::emit_*` helper with fixture input values,
+   inside a registered dummy contract frame.
+2. Asserts the published **topics** equal the exact tuple the emitter
+   constructs (`assert_eq!` on the whole `Vec<Val>` — order, count, and
+   values all have to match).
+3. Decodes the published **data** into the exact Rust type the emitter
+   passed in and asserts it back against the input values. If a field is
+   added, removed, reordered, or retyped, this decode fails (or the
+   `assert_eq!` after it fails).
+4. Builds an `EventSchema` description of what it just observed and
+   compares the whole domain's map against the checked-in fixture here.
+
+Any of those three checks failing means the event's shape drifted from what
+this fixture says a consumer can rely on.
+
+## Updating a fixture on an intentional change
+
+1. Change the `emit_*` helper in `contracts/events/src/lib.rs` as needed.
+2. Update (or add) the corresponding `case_*` function in
+   `tests/event_schema/src/<domain>.rs` so it constructs/decodes the new
+   shape — the compiler will point you at every call site and decode that
+   needs updating.
+3. **Bump `schema_version`** for every changed event in the fixture file.
+4. Update the fixture's `topics`/`data` entries to match the new shape.
+5. Run `cargo test -p event_schema_snapshots` and confirm it's green.
+6. Call out the schema change (event name, old/new shape, new version) in
+   the PR description so SDK/dashboard/indexer owners can update their
+   parsers before this lands.
+
+Do not bump `schema_version` for a change that only affects this
+repo's tests (e.g. reordering `case_*` calls) — only for an actual change
+to what gets published on-chain.
+
+## Adding a new event
+
+1. Add the `emit_*` helper to `contracts/events/src/lib.rs`.
+2. Add a `case_*` function for it in the right `tests/event_schema/src/<domain>.rs`
+   (or create a new domain module + fixture file for a new contract), following
+   the existing cases as a template.
+3. Add its entry to the fixture JSON with `schema_version: 1`.
+4. Run `cargo test -p event_schema_snapshots`.

--- a/tests/event_schema/fixtures/events/audit_module.json
+++ b/tests/event_schema/fixtures/events/audit_module.json
@@ -1,0 +1,57 @@
+{
+  "audit_module.ViewKeyGenerated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "ViewKeyGenerated" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "expiration_ledger", "type": "u32" }]
+  },
+  "audit_module.AuditAccessRevoked": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "AuditAccessRevoked" },
+      { "type": "Address" },
+      { "type": "Address" }
+    ],
+    "data": []
+  },
+  "audit_module.AuditSuccessful": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "AuditSuccessful" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "scope", "type": "Symbol" }]
+  },
+  "audit_module.AggregateAuditGenerated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "AggregateAuditGenerated" },
+      { "type": "Address" }
+    ],
+    "data": [
+      { "name": "company_id", "type": "Symbol" },
+      { "name": "period_start", "type": "u64" },
+      { "name": "period_end", "type": "u64" }
+    ]
+  },
+  "audit_module.AuditSummaryExported": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "AuditSummaryExported" },
+      { "type": "Address" }
+    ],
+    "data": [
+      { "name": "company_id", "type": "Symbol" },
+      { "name": "period_start", "type": "u64" },
+      { "name": "period_end", "type": "u64" },
+      { "name": "total", "type": "u32" }
+    ]
+  },
+  "audit_module.AuditPauseMgrSet": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "AuditPauseMgrSet" }],
+    "data": [{ "name": "pause_manager", "type": "Address" }]
+  }
+}

--- a/tests/event_schema/fixtures/events/pause_manager.json
+++ b/tests/event_schema/fixtures/events/pause_manager.json
@@ -1,0 +1,53 @@
+{
+  "pause_manager.initialized": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PauseManager" },
+      { "type": "Symbol", "value": "initialized" }
+    ],
+    "data": [{ "name": "operator", "type": "Address" }]
+  },
+  "pause_manager.paused": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PauseManager" },
+      { "type": "Symbol", "value": "paused" }
+    ],
+    "data": []
+  },
+  "pause_manager.unpaused": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PauseManager" },
+      { "type": "Symbol", "value": "unpaused" }
+    ],
+    "data": []
+  },
+  "pause_manager.op_proposed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PauseManager" },
+      { "type": "Symbol", "value": "op_proposed" }
+    ],
+    "data": [
+      { "name": "current", "type": "Address" },
+      { "name": "new_op", "type": "Address" }
+    ]
+  },
+  "pause_manager.op_rotated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PauseManager" },
+      { "type": "Symbol", "value": "op_rotated" }
+    ],
+    "data": [{ "name": "new_op", "type": "Address" }]
+  },
+  "pause_manager.op_cancelled": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PauseManager" },
+      { "type": "Symbol", "value": "op_cancelled" }
+    ],
+    "data": [{ "name": "current", "type": "Address" }]
+  }
+}

--- a/tests/event_schema/fixtures/events/payment_executor.json
+++ b/tests/event_schema/fixtures/events/payment_executor.json
@@ -1,0 +1,56 @@
+{
+  "payment_executor.ExecutorInitialized": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "ExecutorInitialized" }],
+    "data": [
+      { "name": "registry", "type": "Address" },
+      { "name": "token", "type": "Address" }
+    ]
+  },
+  "payment_executor.ExecutorAdminSet": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "ExecutorAdminSet" }],
+    "data": [{ "name": "admin", "type": "Address" }]
+  },
+  "payment_executor.ExecutorPauseMgrSet": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "ExecutorPauseMgrSet" }],
+    "data": [{ "name": "pause_manager", "type": "Address" }]
+  },
+  "payment_executor.PeriodCreated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PeriodCreated" },
+      { "type": "u64" }
+    ],
+    "data": [{ "name": "period_id", "type": "u32" }]
+  },
+  "payment_executor.PeriodClosed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PeriodClosed" },
+      { "type": "u64" }
+    ],
+    "data": [{ "name": "period_id", "type": "u32" }]
+  },
+  "payment_executor.PayrollProcessed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "PayrollProcessed" },
+      { "type": "u64" }
+    ],
+    "data": [
+      { "name": "employee", "type": "Address" },
+      { "name": "amount", "type": "i128" },
+      { "name": "period", "type": "u32" }
+    ]
+  },
+  "payment_executor.AssetAllowedChanged": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "AssetAllowedChanged" }],
+    "data": [
+      { "name": "asset", "type": "Address" },
+      { "name": "allowed", "type": "bool" }
+    ]
+  }
+}

--- a/tests/event_schema/fixtures/events/payroll.json
+++ b/tests/event_schema/fixtures/events/payroll.json
@@ -1,0 +1,329 @@
+{
+  "payroll.initialized": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "initialized" }
+    ],
+    "data": [
+      { "name": "admin", "type": "Address" },
+      { "name": "token", "type": "Address" },
+      { "name": "verifier", "type": "Address" },
+      { "name": "commitment", "type": "Address" },
+      { "name": "treasury", "type": "Address" },
+      { "name": "treasury_owner", "type": "Address" }
+    ]
+  },
+  "payroll.pause_mgr_set": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "pause_mgr_set" }
+    ],
+    "data": [{ "name": "pause_manager", "type": "Address" }]
+  },
+  "payroll.deposit": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "deposit" }
+    ],
+    "data": [
+      { "name": "from", "type": "Address" },
+      { "name": "amount", "type": "i128" },
+      { "name": "deposit_id", "type": "BytesN<32>" }
+    ]
+  },
+  "payroll.meta_committed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "meta_committed" }
+    ],
+    "data": [{ "name": "metadata_hash", "type": "BytesN<32>" }]
+  },
+  "payroll.meta_bound": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "meta_bound" }
+    ],
+    "data": [
+      { "name": "run_id", "type": "u64" },
+      { "name": "metadata_hash", "type": "BytesN<32>" }
+    ]
+  },
+  "payroll.draft_committed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "draft_committed" }
+    ],
+    "data": [{ "name": "draft_hash", "type": "BytesN<32>" }]
+  },
+  "payroll.emrg_requested": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "emrg_requested" }
+    ],
+    "data": [
+      { "name": "amount", "type": "i128" },
+      { "name": "recipient", "type": "Address" }
+    ]
+  },
+  "payroll.emrg_approved": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "emrg_approved" }
+    ],
+    "data": [
+      { "name": "amount", "type": "i128" },
+      { "name": "recipient", "type": "Address" }
+    ]
+  },
+  "payroll.emrg_cancelled": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "emrg_cancelled" }
+    ],
+    "data": [{ "name": "caller", "type": "Address" }]
+  },
+  "payroll.run_prepared": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "run_prepared" }
+    ],
+    "data": [
+      { "name": "run_id", "type": "u64" },
+      { "name": "total_spend", "type": "i128" }
+    ]
+  },
+  "payroll.run_cancelled": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "run_cancelled" }
+    ],
+    "data": [
+      { "name": "run_id", "type": "u64" },
+      { "name": "total_amount", "type": "i128" }
+    ]
+  },
+  "payroll.payment_executed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "payment_executed" }
+    ],
+    "data": [
+      { "name": "employee", "type": "Address" },
+      { "name": "amount", "type": "i128" }
+    ]
+  },
+  "payroll.run_executed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "run_executed" }
+    ],
+    "data": [
+      { "name": "run_id", "type": "u64" },
+      { "name": "total_spend", "type": "i128" }
+    ]
+  },
+  "payroll.draft_created": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "draft_created" }
+    ],
+    "data": [
+      { "name": "draft_id", "type": "u64" },
+      { "name": "admin", "type": "Address" },
+      { "name": "period_label", "type": "Symbol" }
+    ]
+  },
+  "payroll.draft_amended": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "draft_amended" }
+    ],
+    "data": [
+      { "name": "draft_id", "type": "u64" },
+      { "name": "new_total", "type": "i128" },
+      { "name": "amendment_count", "type": "u32" }
+    ]
+  },
+  "payroll.draft_finalized": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "draft_finalized" }
+    ],
+    "data": [
+      { "name": "draft_id", "type": "u64" },
+      { "name": "total", "type": "i128" },
+      { "name": "amendment_count", "type": "u32" }
+    ]
+  },
+  "payroll.draft_submitted": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "draft_submitted" }
+    ],
+    "data": [
+      { "name": "draft_id", "type": "u64" },
+      { "name": "admin", "type": "Address" }
+    ]
+  },
+  "payroll.draft_cancelled": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "draft_cancelled" }
+    ],
+    "data": [
+      { "name": "draft_id", "type": "u64" },
+      { "name": "admin", "type": "Address" }
+    ]
+  },
+  "payroll.draft_expired": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "draft_expired" }
+    ],
+    "data": [
+      { "name": "draft_id", "type": "u64" },
+      { "name": "admin", "type": "Address" }
+    ]
+  },
+  "payroll.reconciliation_updated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "reconciliation_updated" }
+    ],
+    "data": [
+      { "name": "run_id", "type": "u64" },
+      { "name": "status", "type": "Symbol" }
+    ]
+  },
+  "payroll.admin_proposed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "admin_proposed" }
+    ],
+    "data": [
+      { "name": "current_admin", "type": "Address" },
+      { "name": "new_admin", "type": "Address" }
+    ]
+  },
+  "payroll.admin_rotated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "admin_rotated" }
+    ],
+    "data": [
+      { "name": "old_admin", "type": "Address" },
+      { "name": "new_admin", "type": "Address" }
+    ]
+  },
+  "payroll.admin_rot_cancel": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "admin_rot_cancel" }
+    ],
+    "data": [{ "name": "caller", "type": "Address" }]
+  },
+  "payroll.treasury_proposed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "treasury_proposed" }
+    ],
+    "data": [
+      { "name": "current_owner", "type": "Address" },
+      { "name": "new_owner", "type": "Address" }
+    ]
+  },
+  "payroll.treasury_rotated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "treasury_rotated" }
+    ],
+    "data": [
+      { "name": "old_owner", "type": "Address" },
+      { "name": "new_owner", "type": "Address" }
+    ]
+  },
+  "payroll.treas_rot_cancel": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "treas_rot_cancel" }
+    ],
+    "data": [{ "name": "caller", "type": "Address" }]
+  },
+  "payroll.reviewer_added": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "reviewer_added" }
+    ],
+    "data": [{ "name": "reviewer", "type": "Address" }]
+  },
+  "payroll.reviewer_removed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "reviewer_removed" }
+    ],
+    "data": [{ "name": "reviewer", "type": "Address" }]
+  },
+  "payroll.run_approved": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "run_approved" }
+    ],
+    "data": [
+      { "name": "run_id", "type": "u64" },
+      { "name": "reviewer", "type": "Address" }
+    ]
+  },
+  "payroll.run_rejected": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "run_rejected" }
+    ],
+    "data": [
+      { "name": "run_id", "type": "u64" },
+      { "name": "reviewer", "type": "Address" },
+      { "name": "reason", "type": "Symbol" }
+    ]
+  },
+  "payroll.changes_requested": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "payroll" },
+      { "type": "Symbol", "value": "changes_requested" }
+    ],
+    "data": [
+      { "name": "run_id", "type": "u64" },
+      { "name": "reviewer", "type": "Address" },
+      { "name": "reason", "type": "Symbol" }
+    ]
+  }
+}

--- a/tests/event_schema/fixtures/events/registry.json
+++ b/tests/event_schema/fixtures/events/registry.json
@@ -1,0 +1,111 @@
+{
+  "registry.CompanyRegistered": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CompanyRegistered" },
+      { "type": "u64" }
+    ],
+    "data": [
+      { "name": "admin", "type": "Address" },
+      { "name": "treasury", "type": "Address" }
+    ]
+  },
+  "registry.EmployeeAdded": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "EmployeeAdded" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "commitment", "type": "BytesN<32>" }]
+  },
+  "registry.EmployeeRemoved": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "EmployeeRemoved" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": []
+  },
+  "registry.CommitmentUpdated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CommitmentUpdated" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "new_commitment", "type": "BytesN<32>" }]
+  },
+  "registry.EmployeeStatusChanged": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "EmployeeStatusChanged" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": [
+      { "name": "previous_status", "type": "Symbol" },
+      { "name": "new_status", "type": "Symbol" }
+    ]
+  },
+  "registry.RegistryPauseMgrSet": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "RegistryPauseMgrSet" }],
+    "data": [{ "name": "pause_manager", "type": "Address" }]
+  },
+  "registry.CompanyAdminProposed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CompanyAdminProposed" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "new_admin", "type": "Address" }]
+  },
+  "registry.CompanyAdminRotated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CompanyAdminRotated" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "new_admin", "type": "Address" }]
+  },
+  "registry.CompanyAdminRotCancelled": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CompanyAdminRotCancelled" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": []
+  },
+  "registry.CompanyTreasProposed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CompanyTreasProposed" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "new_treasury", "type": "Address" }]
+  },
+  "registry.CompanyTreasRotated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CompanyTreasRotated" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "new_treasury", "type": "Address" }]
+  },
+  "registry.CompanyTreasRotCancelled": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CompanyTreasRotCancelled" },
+      { "type": "u64" },
+      { "type": "Address" }
+    ],
+    "data": []
+  }
+}

--- a/tests/event_schema/fixtures/events/salary_commitment.json
+++ b/tests/event_schema/fixtures/events/salary_commitment.json
@@ -1,0 +1,84 @@
+{
+  "salary_commitment.CommitmentUpdated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CommitmentUpdated" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "commitment", "type": "BytesN<32>" }]
+  },
+  "salary_commitment.CommitmentRotated": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CommitmentRotated" },
+      { "type": "Address" }
+    ],
+    "data": [
+      { "name": "old_commitment", "type": "BytesN<32>" },
+      { "name": "new_commitment", "type": "BytesN<32>" }
+    ]
+  },
+  "salary_commitment.CommitmentLocked": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CommitmentLocked" },
+      { "type": "Address" }
+    ],
+    "data": []
+  },
+  "salary_commitment.CommitmentUnlocked": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "CommitmentUnlocked" },
+      { "type": "Address" }
+    ],
+    "data": []
+  },
+  "salary_commitment.ReferenceIdSet": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "ReferenceIdSet" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "reference_id", "type": "String" }]
+  },
+  "salary_commitment.NullifierRecorded": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "NullifierRecorded" }],
+    "data": [{ "name": "nullifier", "type": "BytesN<32>" }]
+  },
+  "salary_commitment.PayrollOperatorSet": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "PayrollOperatorSet" }],
+    "data": [{ "name": "operator", "type": "Address" }]
+  },
+  "salary_commitment.AdminRotationProposed": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "AdminRotationProposed" },
+      { "type": "Address" }
+    ],
+    "data": [{ "name": "new_admin", "type": "Address" }]
+  },
+  "salary_commitment.AdminRotationAccepted": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "AdminRotationAccepted" },
+      { "type": "Address" }
+    ],
+    "data": []
+  },
+  "salary_commitment.AdminRotationCancelled": {
+    "schema_version": 1,
+    "topics": [
+      { "type": "Symbol", "value": "AdminRotationCancelled" },
+      { "type": "Address" }
+    ],
+    "data": []
+  },
+  "salary_commitment.CommitPauseMgrSet": {
+    "schema_version": 1,
+    "topics": [{ "type": "Symbol", "value": "CommitPauseMgrSet" }],
+    "data": [{ "name": "pause_manager", "type": "Address" }]
+  }
+}

--- a/tests/event_schema/src/audit_module.rs
+++ b/tests/event_schema/src/audit_module.rs
@@ -1,0 +1,235 @@
+//! Snapshot coverage for every event emitted by the Audit Module contract
+//! (`contracts/events/src/lib.rs`, "Audit Module Events" section).
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, IntoVal, Symbol, TryIntoVal, Val, Vec as SVec};
+
+use crate::support::{
+    assert_matches_fixture, dynamic, field, last_event, new_env, sym, EventSchema, SchemaMap,
+};
+
+fn case_view_key_generated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let auditor = Address::generate(env);
+    let expiration_ledger: u32 = 100_000;
+    env.as_contract(cid, || {
+        payroll_events::emit_view_key_generated(env, auditor.clone(), expiration_ledger);
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "ViewKeyGenerated"), auditor.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "audit_module.ViewKeyGenerated topics changed"
+    );
+    let decoded: (u32,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (expiration_ledger,),
+        "audit_module.ViewKeyGenerated payload changed"
+    );
+    out.insert(
+        "audit_module.ViewKeyGenerated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("ViewKeyGenerated"), dynamic("Address")],
+            data: vec![field("expiration_ledger", "u32")],
+        },
+    );
+}
+
+fn case_audit_access_revoked(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let admin = Address::generate(env);
+    let auditor = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_audit_access_revoked(env, admin.clone(), auditor.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "AuditAccessRevoked"),
+        admin.clone(),
+        auditor.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "audit_module.AuditAccessRevoked topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (),
+        "audit_module.AuditAccessRevoked payload changed"
+    );
+    out.insert(
+        "audit_module.AuditAccessRevoked".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![
+                sym("AuditAccessRevoked"),
+                dynamic("Address"),
+                dynamic("Address"),
+            ],
+            data: vec![],
+        },
+    );
+}
+
+fn case_audit_successful(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let auditor = Address::generate(env);
+    let scope = Symbol::new(env, "full");
+    env.as_contract(cid, || {
+        payroll_events::emit_audit_successful(env, auditor.clone(), scope.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "AuditSuccessful"), auditor.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "audit_module.AuditSuccessful topics changed"
+    );
+    let decoded: (Symbol,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (scope,),
+        "audit_module.AuditSuccessful payload changed"
+    );
+    out.insert(
+        "audit_module.AuditSuccessful".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("AuditSuccessful"), dynamic("Address")],
+            data: vec![field("scope", "Symbol")],
+        },
+    );
+}
+
+fn case_aggregate_audit_generated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let auditor = Address::generate(env);
+    let company_id = Symbol::new(env, "company_1");
+    let period_start: u64 = 1_000;
+    let period_end: u64 = 2_000;
+    env.as_contract(cid, || {
+        payroll_events::emit_aggregate_audit_generated(
+            env,
+            auditor.clone(),
+            company_id.clone(),
+            period_start,
+            period_end,
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "AggregateAuditGenerated"), auditor.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "audit_module.AggregateAuditGenerated topics changed"
+    );
+    let decoded: (Symbol, u64, u64) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (company_id, period_start, period_end),
+        "audit_module.AggregateAuditGenerated payload changed"
+    );
+    out.insert(
+        "audit_module.AggregateAuditGenerated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("AggregateAuditGenerated"), dynamic("Address")],
+            data: vec![
+                field("company_id", "Symbol"),
+                field("period_start", "u64"),
+                field("period_end", "u64"),
+            ],
+        },
+    );
+}
+
+fn case_audit_summary_exported(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let auditor = Address::generate(env);
+    let company_id = Symbol::new(env, "company_2");
+    let period_start: u64 = 3_000;
+    let period_end: u64 = 4_000;
+    let total: u32 = 12;
+    env.as_contract(cid, || {
+        payroll_events::emit_audit_summary_exported(
+            env,
+            auditor.clone(),
+            company_id.clone(),
+            period_start,
+            period_end,
+            total,
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "AuditSummaryExported"), auditor.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "audit_module.AuditSummaryExported topics changed"
+    );
+    let decoded: (Symbol, u64, u64, u32) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (company_id, period_start, period_end, total),
+        "audit_module.AuditSummaryExported payload changed"
+    );
+    out.insert(
+        "audit_module.AuditSummaryExported".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("AuditSummaryExported"), dynamic("Address")],
+            data: vec![
+                field("company_id", "Symbol"),
+                field("period_start", "u64"),
+                field("period_end", "u64"),
+                field("total", "u32"),
+            ],
+        },
+    );
+}
+
+fn case_audit_pause_manager_set(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let pause_manager = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_audit_pause_manager_set(env, pause_manager.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "AuditPauseMgrSet"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "audit_module.AuditPauseMgrSet topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (pause_manager,),
+        "audit_module.AuditPauseMgrSet payload changed"
+    );
+    out.insert(
+        "audit_module.AuditPauseMgrSet".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("AuditPauseMgrSet")],
+            data: vec![field("pause_manager", "Address")],
+        },
+    );
+}
+
+#[test]
+fn audit_module_events_match_fixture() {
+    let (env, cid) = new_env();
+    let mut observed = SchemaMap::new();
+
+    case_view_key_generated(&env, &cid, &mut observed);
+    case_audit_access_revoked(&env, &cid, &mut observed);
+    case_audit_successful(&env, &cid, &mut observed);
+    case_aggregate_audit_generated(&env, &cid, &mut observed);
+    case_audit_summary_exported(&env, &cid, &mut observed);
+    case_audit_pause_manager_set(&env, &cid, &mut observed);
+
+    assert_matches_fixture(
+        "audit_module",
+        include_str!("../fixtures/events/audit_module.json"),
+        observed,
+    );
+}

--- a/tests/event_schema/src/lib.rs
+++ b/tests/event_schema/src/lib.rs
@@ -1,0 +1,31 @@
+#![cfg(test)]
+
+//! Snapshot tests that pin the wire shape of every Soroban contract event
+//! emitted through the `payroll_events` crate.
+//!
+//! # Why this exists
+//! SDKs, dashboards, indexers, and audit exports all depend on event topics
+//! and payload shapes staying stable. A one-line change to an `emit_*`
+//! helper (reordering a tuple, adding a field, renaming a topic symbol) is
+//! invisible in a normal unit test but silently breaks every off-chain
+//! consumer parsing that event. These tests make that kind of change loud:
+//! they fail if a topic list or payload shape drifts from the checked-in
+//! fixture in `fixtures/events/`.
+//!
+//! # Layout
+//! - `support.rs` — shared capture/compare scaffolding.
+//! - one module per contract domain (`payroll`, `registry`,
+//!   `salary_commitment`, `payment_executor`, `pause_manager`,
+//!   `audit_module`), each with one `#[test]` per emitted event.
+//! - `fixtures/events/*.json` — the checked-in expected schema per domain.
+//! - `fixtures/events/README.md` — how to update a fixture on an intentional
+//!   schema change.
+
+mod support;
+
+mod audit_module;
+mod pause_manager;
+mod payment_executor;
+mod payroll;
+mod registry;
+mod salary_commitment;

--- a/tests/event_schema/src/pause_manager.rs
+++ b/tests/event_schema/src/pause_manager.rs
@@ -1,0 +1,182 @@
+//! Snapshot coverage for every event emitted by the Pause Manager contract
+//! (`contracts/events/src/lib.rs`, "Pause Manager Events" section). Every
+//! event here shares the `(Symbol("PauseManager"), Symbol(<action>))` topic
+//! prefix.
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, IntoVal, Symbol, TryIntoVal, Val, Vec as SVec};
+
+use crate::support::{
+    assert_matches_fixture, field, last_event, new_env, sym, EventSchema, SchemaMap,
+};
+
+fn topic(env: &Env, action: &str) -> SVec<Val> {
+    (Symbol::new(env, "PauseManager"), Symbol::new(env, action)).into_val(env)
+}
+
+fn case_initialized(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let operator = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_pause_manager_initialized(env, operator.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "initialized"),
+        "pause_manager.initialized topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (operator,),
+        "pause_manager.initialized payload changed"
+    );
+    out.insert(
+        "pause_manager.initialized".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PauseManager"), sym("initialized")],
+            data: vec![field("operator", "Address")],
+        },
+    );
+}
+
+fn case_paused(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    env.as_contract(cid, || {
+        payroll_events::emit_paused(env);
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "paused"),
+        "pause_manager.paused topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(decoded, (), "pause_manager.paused payload changed");
+    out.insert(
+        "pause_manager.paused".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PauseManager"), sym("paused")],
+            data: vec![],
+        },
+    );
+}
+
+fn case_unpaused(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    env.as_contract(cid, || {
+        payroll_events::emit_unpaused(env);
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "unpaused"),
+        "pause_manager.unpaused topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(decoded, (), "pause_manager.unpaused payload changed");
+    out.insert(
+        "pause_manager.unpaused".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PauseManager"), sym("unpaused")],
+            data: vec![],
+        },
+    );
+}
+
+fn case_operator_proposed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let current = Address::generate(env);
+    let new_op = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_pause_operator_proposed(env, current.clone(), new_op.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "op_proposed"),
+        "pause_manager.op_proposed topics changed"
+    );
+    let decoded: (Address, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (current, new_op),
+        "pause_manager.op_proposed payload changed"
+    );
+    out.insert(
+        "pause_manager.op_proposed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PauseManager"), sym("op_proposed")],
+            data: vec![field("current", "Address"), field("new_op", "Address")],
+        },
+    );
+}
+
+fn case_operator_rotated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let new_op = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_pause_operator_rotated(env, new_op.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "op_rotated"),
+        "pause_manager.op_rotated topics changed"
+    );
+    let decoded: Address = data.try_into_val(env).unwrap();
+    assert_eq!(decoded, new_op, "pause_manager.op_rotated payload changed");
+    out.insert(
+        "pause_manager.op_rotated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PauseManager"), sym("op_rotated")],
+            data: vec![field("new_op", "Address")],
+        },
+    );
+}
+
+fn case_operator_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let current = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_pause_operator_cancelled(env, current.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "op_cancelled"),
+        "pause_manager.op_cancelled topics changed"
+    );
+    let decoded: Address = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded, current,
+        "pause_manager.op_cancelled payload changed"
+    );
+    out.insert(
+        "pause_manager.op_cancelled".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PauseManager"), sym("op_cancelled")],
+            data: vec![field("current", "Address")],
+        },
+    );
+}
+
+#[test]
+fn pause_manager_events_match_fixture() {
+    let (env, cid) = new_env();
+    let mut observed = SchemaMap::new();
+
+    case_initialized(&env, &cid, &mut observed);
+    case_paused(&env, &cid, &mut observed);
+    case_unpaused(&env, &cid, &mut observed);
+    case_operator_proposed(&env, &cid, &mut observed);
+    case_operator_rotated(&env, &cid, &mut observed);
+    case_operator_cancelled(&env, &cid, &mut observed);
+
+    assert_matches_fixture(
+        "pause_manager",
+        include_str!("../fixtures/events/pause_manager.json"),
+        observed,
+    );
+}

--- a/tests/event_schema/src/payment_executor.rs
+++ b/tests/event_schema/src/payment_executor.rs
@@ -1,0 +1,237 @@
+//! Snapshot coverage for every event emitted by the Payment Executor
+//! contract (`contracts/events/src/lib.rs`, "Payment Executor Events"
+//! section).
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, IntoVal, Symbol, TryIntoVal, Val, Vec as SVec};
+
+use crate::support::{
+    assert_matches_fixture, dynamic, field, last_event, new_env, sym, EventSchema, SchemaMap,
+};
+
+fn case_executor_initialized(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let registry = Address::generate(env);
+    let token = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_executor_initialized(env, registry.clone(), token.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "ExecutorInitialized"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "payment_executor.ExecutorInitialized topics changed"
+    );
+    let decoded: (Address, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (registry, token),
+        "payment_executor.ExecutorInitialized payload changed"
+    );
+    out.insert(
+        "payment_executor.ExecutorInitialized".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("ExecutorInitialized")],
+            data: vec![field("registry", "Address"), field("token", "Address")],
+        },
+    );
+}
+
+fn case_executor_admin_set(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_executor_admin_set(env, admin.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "ExecutorAdminSet"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "payment_executor.ExecutorAdminSet topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (admin,),
+        "payment_executor.ExecutorAdminSet payload changed"
+    );
+    out.insert(
+        "payment_executor.ExecutorAdminSet".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("ExecutorAdminSet")],
+            data: vec![field("admin", "Address")],
+        },
+    );
+}
+
+fn case_executor_pause_manager_set(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let pause_manager = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_executor_pause_manager_set(env, pause_manager.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "ExecutorPauseMgrSet"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "payment_executor.ExecutorPauseMgrSet topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (pause_manager,),
+        "payment_executor.ExecutorPauseMgrSet payload changed"
+    );
+    out.insert(
+        "payment_executor.ExecutorPauseMgrSet".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("ExecutorPauseMgrSet")],
+            data: vec![field("pause_manager", "Address")],
+        },
+    );
+}
+
+fn case_period_created(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 40;
+    let period_id: u32 = 1;
+    env.as_contract(cid, || {
+        payroll_events::emit_period_created(env, company_id, period_id);
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "PeriodCreated"), company_id).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "payment_executor.PeriodCreated topics changed"
+    );
+    let decoded: (u32,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (period_id,),
+        "payment_executor.PeriodCreated payload changed"
+    );
+    out.insert(
+        "payment_executor.PeriodCreated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PeriodCreated"), dynamic("u64")],
+            data: vec![field("period_id", "u32")],
+        },
+    );
+}
+
+fn case_period_closed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 41;
+    let period_id: u32 = 2;
+    env.as_contract(cid, || {
+        payroll_events::emit_period_closed(env, company_id, period_id);
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "PeriodClosed"), company_id).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "payment_executor.PeriodClosed topics changed"
+    );
+    let decoded: (u32,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (period_id,),
+        "payment_executor.PeriodClosed payload changed"
+    );
+    out.insert(
+        "payment_executor.PeriodClosed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PeriodClosed"), dynamic("u64")],
+            data: vec![field("period_id", "u32")],
+        },
+    );
+}
+
+fn case_executor_payment_processed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 42;
+    let employee = Address::generate(env);
+    let amount: i128 = 3_300;
+    let period: u32 = 3;
+    env.as_contract(cid, || {
+        payroll_events::emit_executor_payment_processed(
+            env,
+            company_id,
+            employee.clone(),
+            amount,
+            period,
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "PayrollProcessed"), company_id).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "payment_executor.PayrollProcessed topics changed"
+    );
+    let decoded: (Address, i128, u32) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (employee, amount, period),
+        "payment_executor.PayrollProcessed payload changed"
+    );
+    out.insert(
+        "payment_executor.PayrollProcessed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PayrollProcessed"), dynamic("u64")],
+            data: vec![
+                field("employee", "Address"),
+                field("amount", "i128"),
+                field("period", "u32"),
+            ],
+        },
+    );
+}
+
+fn case_asset_allowed_changed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let asset = Address::generate(env);
+    let allowed = true;
+    env.as_contract(cid, || {
+        payroll_events::emit_asset_allowed_changed(env, asset.clone(), allowed);
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "AssetAllowedChanged"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "payment_executor.AssetAllowedChanged topics changed"
+    );
+    let decoded: (Address, bool) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (asset, allowed),
+        "payment_executor.AssetAllowedChanged payload changed"
+    );
+    out.insert(
+        "payment_executor.AssetAllowedChanged".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("AssetAllowedChanged")],
+            data: vec![field("asset", "Address"), field("allowed", "bool")],
+        },
+    );
+}
+
+#[test]
+fn payment_executor_events_match_fixture() {
+    let (env, cid) = new_env();
+    let mut observed = SchemaMap::new();
+
+    case_executor_initialized(&env, &cid, &mut observed);
+    case_executor_admin_set(&env, &cid, &mut observed);
+    case_executor_pause_manager_set(&env, &cid, &mut observed);
+    case_period_created(&env, &cid, &mut observed);
+    case_period_closed(&env, &cid, &mut observed);
+    case_executor_payment_processed(&env, &cid, &mut observed);
+    case_asset_allowed_changed(&env, &cid, &mut observed);
+
+    assert_matches_fixture(
+        "payment_executor",
+        include_str!("../fixtures/events/payment_executor.json"),
+        observed,
+    );
+}

--- a/tests/event_schema/src/payroll.rs
+++ b/tests/event_schema/src/payroll.rs
@@ -1,0 +1,957 @@
+//! Snapshot coverage for every event emitted by the Payroll contract
+//! (`contracts/events/src/lib.rs`, "Payroll Contract Events" section).
+//!
+//! All events in this domain share the same topic prefix,
+//! `(payroll_events::payroll_topic(), Symbol(<action>))`.
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, IntoVal, Symbol, TryIntoVal, Val, Vec as SVec};
+
+use crate::support::{
+    assert_matches_fixture, field, last_event, new_env, sym, EventSchema, SchemaMap,
+};
+
+fn topic(env: &Env, action: &str) -> SVec<Val> {
+    (payroll_events::payroll_topic(), Symbol::new(env, action)).into_val(env)
+}
+
+fn case_initialized(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let admin = Address::generate(env);
+    let token = Address::generate(env);
+    let verifier = Address::generate(env);
+    let commitment = Address::generate(env);
+    let treasury = Address::generate(env);
+    let treasury_owner = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_payroll_initialized(
+            env,
+            admin.clone(),
+            token.clone(),
+            verifier.clone(),
+            commitment.clone(),
+            treasury.clone(),
+            treasury_owner.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "initialized"),
+        "payroll.initialized topics changed"
+    );
+    let decoded: (Address, Address, Address, Address, Address, Address) =
+        data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (admin, token, verifier, commitment, treasury, treasury_owner),
+        "payroll.initialized payload changed"
+    );
+    out.insert(
+        "payroll.initialized".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("initialized")],
+            data: vec![
+                field("admin", "Address"),
+                field("token", "Address"),
+                field("verifier", "Address"),
+                field("commitment", "Address"),
+                field("treasury", "Address"),
+                field("treasury_owner", "Address"),
+            ],
+        },
+    );
+}
+
+fn case_pause_manager_set(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let pause_manager = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_pause_manager_set(env, pause_manager.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "pause_mgr_set"),
+        "payroll.pause_mgr_set topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (pause_manager,),
+        "payroll.pause_mgr_set payload changed"
+    );
+    out.insert(
+        "payroll.pause_mgr_set".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("pause_mgr_set")],
+            data: vec![field("pause_manager", "Address")],
+        },
+    );
+}
+
+fn case_deposit(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let from = Address::generate(env);
+    let amount: i128 = 5_000;
+    let deposit_id = BytesN::from_array(env, &[1u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_deposit(env, from.clone(), amount, deposit_id.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "deposit"),
+        "payroll.deposit topics changed"
+    );
+    let decoded: (Address, i128, BytesN<32>) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (from, amount, deposit_id),
+        "payroll.deposit payload changed"
+    );
+    out.insert(
+        "payroll.deposit".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("deposit")],
+            data: vec![
+                field("from", "Address"),
+                field("amount", "i128"),
+                field("deposit_id", "BytesN<32>"),
+            ],
+        },
+    );
+}
+
+fn case_metadata_committed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let metadata_hash = BytesN::from_array(env, &[2u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_metadata_committed(env, metadata_hash.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "meta_committed"),
+        "payroll.meta_committed topics changed"
+    );
+    let decoded: BytesN<32> = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded, metadata_hash,
+        "payroll.meta_committed payload changed"
+    );
+    out.insert(
+        "payroll.meta_committed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("meta_committed")],
+            data: vec![field("metadata_hash", "BytesN<32>")],
+        },
+    );
+}
+
+fn case_metadata_bound(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let run_id: u64 = 7;
+    let metadata_hash = BytesN::from_array(env, &[3u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_metadata_bound(env, run_id, metadata_hash.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "meta_bound"),
+        "payroll.meta_bound topics changed"
+    );
+    let decoded: (u64, BytesN<32>) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (run_id, metadata_hash),
+        "payroll.meta_bound payload changed"
+    );
+    out.insert(
+        "payroll.meta_bound".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("meta_bound")],
+            data: vec![field("run_id", "u64"), field("metadata_hash", "BytesN<32>")],
+        },
+    );
+}
+
+fn case_draft_committed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let draft_hash = BytesN::from_array(env, &[4u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_draft_committed(env, draft_hash.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "draft_committed"),
+        "payroll.draft_committed topics changed"
+    );
+    let decoded: BytesN<32> = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded, draft_hash,
+        "payroll.draft_committed payload changed"
+    );
+    out.insert(
+        "payroll.draft_committed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("draft_committed")],
+            data: vec![field("draft_hash", "BytesN<32>")],
+        },
+    );
+}
+
+fn case_emergency_requested(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let amount: i128 = 1_234;
+    let recipient = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_emergency_requested(env, amount, recipient.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "emrg_requested"),
+        "payroll.emrg_requested topics changed"
+    );
+    let decoded: (i128, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (amount, recipient),
+        "payroll.emrg_requested payload changed"
+    );
+    out.insert(
+        "payroll.emrg_requested".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("emrg_requested")],
+            data: vec![field("amount", "i128"), field("recipient", "Address")],
+        },
+    );
+}
+
+fn case_emergency_approved(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let amount: i128 = 4_321;
+    let recipient = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_emergency_approved(env, amount, recipient.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "emrg_approved"),
+        "payroll.emrg_approved topics changed"
+    );
+    let decoded: (i128, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (amount, recipient),
+        "payroll.emrg_approved payload changed"
+    );
+    out.insert(
+        "payroll.emrg_approved".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("emrg_approved")],
+            data: vec![field("amount", "i128"), field("recipient", "Address")],
+        },
+    );
+}
+
+fn case_emergency_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let caller = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_emergency_cancelled(env, caller.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "emrg_cancelled"),
+        "payroll.emrg_cancelled topics changed"
+    );
+    let decoded: Address = data.try_into_val(env).unwrap();
+    assert_eq!(decoded, caller, "payroll.emrg_cancelled payload changed");
+    out.insert(
+        "payroll.emrg_cancelled".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("emrg_cancelled")],
+            data: vec![field("caller", "Address")],
+        },
+    );
+}
+
+fn case_run_prepared(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let run_id: u64 = 11;
+    let total_spend: i128 = 9_000;
+    env.as_contract(cid, || {
+        payroll_events::emit_run_prepared(env, run_id, total_spend);
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "run_prepared"),
+        "payroll.run_prepared topics changed"
+    );
+    let decoded: (u64, i128) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (run_id, total_spend),
+        "payroll.run_prepared payload changed"
+    );
+    out.insert(
+        "payroll.run_prepared".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("run_prepared")],
+            data: vec![field("run_id", "u64"), field("total_spend", "i128")],
+        },
+    );
+}
+
+fn case_run_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let run_id: u64 = 12;
+    let total_amount: i128 = 8_000;
+    env.as_contract(cid, || {
+        payroll_events::emit_run_cancelled(env, run_id, total_amount);
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "run_cancelled"),
+        "payroll.run_cancelled topics changed"
+    );
+    let decoded: (u64, i128) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (run_id, total_amount),
+        "payroll.run_cancelled payload changed"
+    );
+    out.insert(
+        "payroll.run_cancelled".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("run_cancelled")],
+            data: vec![field("run_id", "u64"), field("total_amount", "i128")],
+        },
+    );
+}
+
+fn case_payment_executed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let employee = Address::generate(env);
+    let amount: i128 = 2_500;
+    env.as_contract(cid, || {
+        payroll_events::emit_payment_executed(env, employee.clone(), amount);
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "payment_executed"),
+        "payroll.payment_executed topics changed"
+    );
+    let decoded: (Address, i128) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (employee, amount),
+        "payroll.payment_executed payload changed"
+    );
+    out.insert(
+        "payroll.payment_executed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("payment_executed")],
+            data: vec![field("employee", "Address"), field("amount", "i128")],
+        },
+    );
+}
+
+fn case_run_executed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let run_id: u64 = 13;
+    let total_spend: i128 = 7_500;
+    env.as_contract(cid, || {
+        payroll_events::emit_run_executed(env, run_id, total_spend);
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "run_executed"),
+        "payroll.run_executed topics changed"
+    );
+    let decoded: (u64, i128) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (run_id, total_spend),
+        "payroll.run_executed payload changed"
+    );
+    out.insert(
+        "payroll.run_executed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("run_executed")],
+            data: vec![field("run_id", "u64"), field("total_spend", "i128")],
+        },
+    );
+}
+
+fn case_draft_created(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let draft_id: u64 = 21;
+    let admin = Address::generate(env);
+    let period_label = Symbol::new(env, "period_1");
+    env.as_contract(cid, || {
+        payroll_events::emit_draft_created(env, draft_id, admin.clone(), period_label.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "draft_created"),
+        "payroll.draft_created topics changed"
+    );
+    let decoded: (u64, Address, Symbol) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (draft_id, admin, period_label),
+        "payroll.draft_created payload changed"
+    );
+    out.insert(
+        "payroll.draft_created".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("draft_created")],
+            data: vec![
+                field("draft_id", "u64"),
+                field("admin", "Address"),
+                field("period_label", "Symbol"),
+            ],
+        },
+    );
+}
+
+fn case_draft_amended(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let draft_id: u64 = 22;
+    let new_total: i128 = 6_600;
+    let amendment_count: u32 = 2;
+    env.as_contract(cid, || {
+        payroll_events::emit_draft_amended(env, draft_id, new_total, amendment_count);
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "draft_amended"),
+        "payroll.draft_amended topics changed"
+    );
+    let decoded: (u64, i128, u32) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (draft_id, new_total, amendment_count),
+        "payroll.draft_amended payload changed"
+    );
+    out.insert(
+        "payroll.draft_amended".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("draft_amended")],
+            data: vec![
+                field("draft_id", "u64"),
+                field("new_total", "i128"),
+                field("amendment_count", "u32"),
+            ],
+        },
+    );
+}
+
+fn case_draft_finalized(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let draft_id: u64 = 23;
+    let total: i128 = 6_700;
+    let amendment_count: u32 = 3;
+    env.as_contract(cid, || {
+        payroll_events::emit_draft_finalized(env, draft_id, total, amendment_count);
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "draft_finalized"),
+        "payroll.draft_finalized topics changed"
+    );
+    let decoded: (u64, i128, u32) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (draft_id, total, amendment_count),
+        "payroll.draft_finalized payload changed"
+    );
+    out.insert(
+        "payroll.draft_finalized".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("draft_finalized")],
+            data: vec![
+                field("draft_id", "u64"),
+                field("total", "i128"),
+                field("amendment_count", "u32"),
+            ],
+        },
+    );
+}
+
+fn case_draft_submitted(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let draft_id: u64 = 24;
+    let admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_draft_submitted(env, draft_id, admin.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "draft_submitted"),
+        "payroll.draft_submitted topics changed"
+    );
+    let decoded: (u64, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (draft_id, admin),
+        "payroll.draft_submitted payload changed"
+    );
+    out.insert(
+        "payroll.draft_submitted".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("draft_submitted")],
+            data: vec![field("draft_id", "u64"), field("admin", "Address")],
+        },
+    );
+}
+
+fn case_draft_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let draft_id: u64 = 25;
+    let admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_draft_cancelled(env, draft_id, admin.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "draft_cancelled"),
+        "payroll.draft_cancelled topics changed"
+    );
+    let decoded: (u64, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (draft_id, admin),
+        "payroll.draft_cancelled payload changed"
+    );
+    out.insert(
+        "payroll.draft_cancelled".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("draft_cancelled")],
+            data: vec![field("draft_id", "u64"), field("admin", "Address")],
+        },
+    );
+}
+
+fn case_draft_expired(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let draft_id: u64 = 26;
+    let admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_draft_expired(env, draft_id, admin.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "draft_expired"),
+        "payroll.draft_expired topics changed"
+    );
+    let decoded: (u64, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (draft_id, admin),
+        "payroll.draft_expired payload changed"
+    );
+    out.insert(
+        "payroll.draft_expired".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("draft_expired")],
+            data: vec![field("draft_id", "u64"), field("admin", "Address")],
+        },
+    );
+}
+
+fn case_reconciliation_updated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let run_id: u64 = 27;
+    let status = Symbol::new(env, "reconciled");
+    env.as_contract(cid, || {
+        payroll_events::emit_reconciliation_updated(env, run_id, status.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "reconciliation_updated"),
+        "payroll.reconciliation_updated topics changed"
+    );
+    let decoded: (u64, Symbol) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (run_id, status),
+        "payroll.reconciliation_updated payload changed"
+    );
+    out.insert(
+        "payroll.reconciliation_updated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("reconciliation_updated")],
+            data: vec![field("run_id", "u64"), field("status", "Symbol")],
+        },
+    );
+}
+
+fn case_admin_proposed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let current_admin = Address::generate(env);
+    let new_admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_admin_proposed(env, current_admin.clone(), new_admin.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "admin_proposed"),
+        "payroll.admin_proposed topics changed"
+    );
+    let decoded: (Address, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (current_admin, new_admin),
+        "payroll.admin_proposed payload changed"
+    );
+    out.insert(
+        "payroll.admin_proposed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("admin_proposed")],
+            data: vec![
+                field("current_admin", "Address"),
+                field("new_admin", "Address"),
+            ],
+        },
+    );
+}
+
+fn case_admin_rotated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let old_admin = Address::generate(env);
+    let new_admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_admin_rotated(env, old_admin.clone(), new_admin.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "admin_rotated"),
+        "payroll.admin_rotated topics changed"
+    );
+    let decoded: (Address, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (old_admin, new_admin),
+        "payroll.admin_rotated payload changed"
+    );
+    out.insert(
+        "payroll.admin_rotated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("admin_rotated")],
+            data: vec![field("old_admin", "Address"), field("new_admin", "Address")],
+        },
+    );
+}
+
+fn case_admin_rotation_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let caller = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_admin_rotation_cancelled(env, caller.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "admin_rot_cancel"),
+        "payroll.admin_rot_cancel topics changed"
+    );
+    let decoded: Address = data.try_into_val(env).unwrap();
+    assert_eq!(decoded, caller, "payroll.admin_rot_cancel payload changed");
+    out.insert(
+        "payroll.admin_rot_cancel".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("admin_rot_cancel")],
+            data: vec![field("caller", "Address")],
+        },
+    );
+}
+
+fn case_treasury_proposed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let current_owner = Address::generate(env);
+    let new_owner = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_treasury_proposed(env, current_owner.clone(), new_owner.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "treasury_proposed"),
+        "payroll.treasury_proposed topics changed"
+    );
+    let decoded: (Address, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (current_owner, new_owner),
+        "payroll.treasury_proposed payload changed"
+    );
+    out.insert(
+        "payroll.treasury_proposed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("treasury_proposed")],
+            data: vec![
+                field("current_owner", "Address"),
+                field("new_owner", "Address"),
+            ],
+        },
+    );
+}
+
+fn case_treasury_rotated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let old_owner = Address::generate(env);
+    let new_owner = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_treasury_rotated(env, old_owner.clone(), new_owner.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "treasury_rotated"),
+        "payroll.treasury_rotated topics changed"
+    );
+    let decoded: (Address, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (old_owner, new_owner),
+        "payroll.treasury_rotated payload changed"
+    );
+    out.insert(
+        "payroll.treasury_rotated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("treasury_rotated")],
+            data: vec![field("old_owner", "Address"), field("new_owner", "Address")],
+        },
+    );
+}
+
+fn case_treasury_rotation_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let caller = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_treasury_rotation_cancelled(env, caller.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "treas_rot_cancel"),
+        "payroll.treas_rot_cancel topics changed"
+    );
+    let decoded: Address = data.try_into_val(env).unwrap();
+    assert_eq!(decoded, caller, "payroll.treas_rot_cancel payload changed");
+    out.insert(
+        "payroll.treas_rot_cancel".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("treas_rot_cancel")],
+            data: vec![field("caller", "Address")],
+        },
+    );
+}
+
+fn case_reviewer_added(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let reviewer = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_reviewer_added(env, reviewer.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "reviewer_added"),
+        "payroll.reviewer_added topics changed"
+    );
+    let decoded: Address = data.try_into_val(env).unwrap();
+    assert_eq!(decoded, reviewer, "payroll.reviewer_added payload changed");
+    out.insert(
+        "payroll.reviewer_added".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("reviewer_added")],
+            data: vec![field("reviewer", "Address")],
+        },
+    );
+}
+
+fn case_reviewer_removed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let reviewer = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_reviewer_removed(env, reviewer.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "reviewer_removed"),
+        "payroll.reviewer_removed topics changed"
+    );
+    let decoded: Address = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded, reviewer,
+        "payroll.reviewer_removed payload changed"
+    );
+    out.insert(
+        "payroll.reviewer_removed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("reviewer_removed")],
+            data: vec![field("reviewer", "Address")],
+        },
+    );
+}
+
+fn case_run_approved(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let run_id: u64 = 31;
+    let reviewer = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_run_approved(env, run_id, reviewer.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "run_approved"),
+        "payroll.run_approved topics changed"
+    );
+    let decoded: (u64, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (run_id, reviewer),
+        "payroll.run_approved payload changed"
+    );
+    out.insert(
+        "payroll.run_approved".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("run_approved")],
+            data: vec![field("run_id", "u64"), field("reviewer", "Address")],
+        },
+    );
+}
+
+fn case_run_rejected(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let run_id: u64 = 32;
+    let reviewer = Address::generate(env);
+    let reason = Symbol::new(env, "policy");
+    env.as_contract(cid, || {
+        payroll_events::emit_run_rejected(env, run_id, reviewer.clone(), reason.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "run_rejected"),
+        "payroll.run_rejected topics changed"
+    );
+    let decoded: (u64, Address, Symbol) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (run_id, reviewer, reason),
+        "payroll.run_rejected payload changed"
+    );
+    out.insert(
+        "payroll.run_rejected".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("run_rejected")],
+            data: vec![
+                field("run_id", "u64"),
+                field("reviewer", "Address"),
+                field("reason", "Symbol"),
+            ],
+        },
+    );
+}
+
+fn case_run_changes_requested(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let run_id: u64 = 33;
+    let reviewer = Address::generate(env);
+    let reason = Symbol::new(env, "missing_docs");
+    env.as_contract(cid, || {
+        payroll_events::emit_run_changes_requested(env, run_id, reviewer.clone(), reason.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    assert_eq!(
+        topics,
+        topic(env, "changes_requested"),
+        "payroll.changes_requested topics changed"
+    );
+    let decoded: (u64, Address, Symbol) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (run_id, reviewer, reason),
+        "payroll.changes_requested payload changed"
+    );
+    out.insert(
+        "payroll.changes_requested".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("payroll"), sym("changes_requested")],
+            data: vec![
+                field("run_id", "u64"),
+                field("reviewer", "Address"),
+                field("reason", "Symbol"),
+            ],
+        },
+    );
+}
+
+#[test]
+fn payroll_events_match_fixture() {
+    let (env, cid) = new_env();
+    let mut observed = SchemaMap::new();
+
+    case_initialized(&env, &cid, &mut observed);
+    case_pause_manager_set(&env, &cid, &mut observed);
+    case_deposit(&env, &cid, &mut observed);
+    case_metadata_committed(&env, &cid, &mut observed);
+    case_metadata_bound(&env, &cid, &mut observed);
+    case_draft_committed(&env, &cid, &mut observed);
+    case_emergency_requested(&env, &cid, &mut observed);
+    case_emergency_approved(&env, &cid, &mut observed);
+    case_emergency_cancelled(&env, &cid, &mut observed);
+    case_run_prepared(&env, &cid, &mut observed);
+    case_run_cancelled(&env, &cid, &mut observed);
+    case_payment_executed(&env, &cid, &mut observed);
+    case_run_executed(&env, &cid, &mut observed);
+    case_draft_created(&env, &cid, &mut observed);
+    case_draft_amended(&env, &cid, &mut observed);
+    case_draft_finalized(&env, &cid, &mut observed);
+    case_draft_submitted(&env, &cid, &mut observed);
+    case_draft_cancelled(&env, &cid, &mut observed);
+    case_draft_expired(&env, &cid, &mut observed);
+    case_reconciliation_updated(&env, &cid, &mut observed);
+    case_admin_proposed(&env, &cid, &mut observed);
+    case_admin_rotated(&env, &cid, &mut observed);
+    case_admin_rotation_cancelled(&env, &cid, &mut observed);
+    case_treasury_proposed(&env, &cid, &mut observed);
+    case_treasury_rotated(&env, &cid, &mut observed);
+    case_treasury_rotation_cancelled(&env, &cid, &mut observed);
+    case_reviewer_added(&env, &cid, &mut observed);
+    case_reviewer_removed(&env, &cid, &mut observed);
+    case_run_approved(&env, &cid, &mut observed);
+    case_run_rejected(&env, &cid, &mut observed);
+    case_run_changes_requested(&env, &cid, &mut observed);
+
+    assert_matches_fixture(
+        "payroll",
+        include_str!("../fixtures/events/payroll.json"),
+        observed,
+    );
+}

--- a/tests/event_schema/src/registry.rs
+++ b/tests/event_schema/src/registry.rs
@@ -1,0 +1,490 @@
+//! Snapshot coverage for every event emitted by the Payroll Registry
+//! contract (`contracts/events/src/lib.rs`, "Payroll Registry Events"
+//! section). Unlike the Payroll domain, each event here uses its own
+//! PascalCase topic symbol (preserved for backward compatibility) rather
+//! than a shared domain prefix.
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, IntoVal, Symbol, TryIntoVal, Val, Vec as SVec};
+
+use crate::support::{
+    assert_matches_fixture, dynamic, field, last_event, new_env, sym, EventSchema, SchemaMap,
+};
+
+fn case_company_registered(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 1;
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_company_registered(env, company_id, admin.clone(), treasury.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "CompanyRegistered"), company_id).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.CompanyRegistered topics changed"
+    );
+    let decoded: (Address, Address) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (admin, treasury),
+        "registry.CompanyRegistered payload changed"
+    );
+    out.insert(
+        "registry.CompanyRegistered".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("CompanyRegistered"), dynamic("u64")],
+            data: vec![field("admin", "Address"), field("treasury", "Address")],
+        },
+    );
+}
+
+fn case_employee_added(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 2;
+    let employee = Address::generate(env);
+    let commitment = BytesN::from_array(env, &[10u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_employee_added(env, company_id, employee.clone(), commitment.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "EmployeeAdded"),
+        company_id,
+        employee.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.EmployeeAdded topics changed"
+    );
+    let decoded: (BytesN<32>,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (commitment,),
+        "registry.EmployeeAdded payload changed"
+    );
+    out.insert(
+        "registry.EmployeeAdded".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("EmployeeAdded"), dynamic("u64"), dynamic("Address")],
+            data: vec![field("commitment", "BytesN<32>")],
+        },
+    );
+}
+
+fn case_employee_removed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 3;
+    let employee = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_employee_removed(env, company_id, employee.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "EmployeeRemoved"),
+        company_id,
+        employee.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.EmployeeRemoved topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(decoded, (), "registry.EmployeeRemoved payload changed");
+    out.insert(
+        "registry.EmployeeRemoved".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("EmployeeRemoved"), dynamic("u64"), dynamic("Address")],
+            data: vec![],
+        },
+    );
+}
+
+fn case_commitment_updated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 4;
+    let employee = Address::generate(env);
+    let new_commitment = BytesN::from_array(env, &[11u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_registry_commitment_updated(
+            env,
+            company_id,
+            employee.clone(),
+            new_commitment.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "CommitmentUpdated"),
+        company_id,
+        employee.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.CommitmentUpdated topics changed"
+    );
+    let decoded: (BytesN<32>,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (new_commitment,),
+        "registry.CommitmentUpdated payload changed"
+    );
+    out.insert(
+        "registry.CommitmentUpdated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("CommitmentUpdated"), dynamic("u64"), dynamic("Address")],
+            data: vec![field("new_commitment", "BytesN<32>")],
+        },
+    );
+}
+
+fn case_employee_status_changed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 5;
+    let employee = Address::generate(env);
+    let previous_status = Symbol::new(env, "active");
+    let new_status = Symbol::new(env, "suspended");
+    env.as_contract(cid, || {
+        payroll_events::emit_employee_status_changed(
+            env,
+            company_id,
+            employee.clone(),
+            previous_status.clone(),
+            new_status.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "EmployeeStatusChanged"),
+        company_id,
+        employee.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.EmployeeStatusChanged topics changed"
+    );
+    let decoded: (Symbol, Symbol) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (previous_status, new_status),
+        "registry.EmployeeStatusChanged payload changed"
+    );
+    out.insert(
+        "registry.EmployeeStatusChanged".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![
+                sym("EmployeeStatusChanged"),
+                dynamic("u64"),
+                dynamic("Address"),
+            ],
+            data: vec![
+                field("previous_status", "Symbol"),
+                field("new_status", "Symbol"),
+            ],
+        },
+    );
+}
+
+fn case_registry_pause_manager_set(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let pause_manager = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_registry_pause_manager_set(env, pause_manager.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "RegistryPauseMgrSet"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.RegistryPauseMgrSet topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (pause_manager,),
+        "registry.RegistryPauseMgrSet payload changed"
+    );
+    out.insert(
+        "registry.RegistryPauseMgrSet".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("RegistryPauseMgrSet")],
+            data: vec![field("pause_manager", "Address")],
+        },
+    );
+}
+
+fn case_company_admin_proposed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 6;
+    let current_admin = Address::generate(env);
+    let new_admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_company_admin_proposed(
+            env,
+            company_id,
+            current_admin.clone(),
+            new_admin.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "CompanyAdminProposed"),
+        company_id,
+        current_admin.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.CompanyAdminProposed topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (new_admin,),
+        "registry.CompanyAdminProposed payload changed"
+    );
+    out.insert(
+        "registry.CompanyAdminProposed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![
+                sym("CompanyAdminProposed"),
+                dynamic("u64"),
+                dynamic("Address"),
+            ],
+            data: vec![field("new_admin", "Address")],
+        },
+    );
+}
+
+fn case_company_admin_rotated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 7;
+    let old_admin = Address::generate(env);
+    let new_admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_company_admin_rotated(
+            env,
+            company_id,
+            old_admin.clone(),
+            new_admin.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "CompanyAdminRotated"),
+        company_id,
+        old_admin.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.CompanyAdminRotated topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (new_admin,),
+        "registry.CompanyAdminRotated payload changed"
+    );
+    out.insert(
+        "registry.CompanyAdminRotated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![
+                sym("CompanyAdminRotated"),
+                dynamic("u64"),
+                dynamic("Address"),
+            ],
+            data: vec![field("new_admin", "Address")],
+        },
+    );
+}
+
+fn case_company_admin_rotation_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 8;
+    let caller = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_company_admin_rotation_cancelled(env, company_id, caller.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "CompanyAdminRotCancelled"),
+        company_id,
+        caller.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.CompanyAdminRotCancelled topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (),
+        "registry.CompanyAdminRotCancelled payload changed"
+    );
+    out.insert(
+        "registry.CompanyAdminRotCancelled".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![
+                sym("CompanyAdminRotCancelled"),
+                dynamic("u64"),
+                dynamic("Address"),
+            ],
+            data: vec![],
+        },
+    );
+}
+
+fn case_company_treasury_proposed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 9;
+    let current_admin = Address::generate(env);
+    let new_treasury = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_company_treasury_proposed(
+            env,
+            company_id,
+            current_admin.clone(),
+            new_treasury.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "CompanyTreasProposed"),
+        company_id,
+        current_admin.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.CompanyTreasProposed topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (new_treasury,),
+        "registry.CompanyTreasProposed payload changed"
+    );
+    out.insert(
+        "registry.CompanyTreasProposed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![
+                sym("CompanyTreasProposed"),
+                dynamic("u64"),
+                dynamic("Address"),
+            ],
+            data: vec![field("new_treasury", "Address")],
+        },
+    );
+}
+
+fn case_company_treasury_rotated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 10;
+    let old_treasury = Address::generate(env);
+    let new_treasury = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_company_treasury_rotated(
+            env,
+            company_id,
+            old_treasury.clone(),
+            new_treasury.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "CompanyTreasRotated"),
+        company_id,
+        old_treasury.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.CompanyTreasRotated topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (new_treasury,),
+        "registry.CompanyTreasRotated payload changed"
+    );
+    out.insert(
+        "registry.CompanyTreasRotated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![
+                sym("CompanyTreasRotated"),
+                dynamic("u64"),
+                dynamic("Address"),
+            ],
+            data: vec![field("new_treasury", "Address")],
+        },
+    );
+}
+
+fn case_company_treasury_rotation_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let company_id: u64 = 11;
+    let caller = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_company_treasury_rotation_cancelled(env, company_id, caller.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "CompanyTreasRotCancelled"),
+        company_id,
+        caller.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "registry.CompanyTreasRotCancelled topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (),
+        "registry.CompanyTreasRotCancelled payload changed"
+    );
+    out.insert(
+        "registry.CompanyTreasRotCancelled".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![
+                sym("CompanyTreasRotCancelled"),
+                dynamic("u64"),
+                dynamic("Address"),
+            ],
+            data: vec![],
+        },
+    );
+}
+
+#[test]
+fn registry_events_match_fixture() {
+    let (env, cid) = new_env();
+    let mut observed = SchemaMap::new();
+
+    case_company_registered(&env, &cid, &mut observed);
+    case_employee_added(&env, &cid, &mut observed);
+    case_employee_removed(&env, &cid, &mut observed);
+    case_commitment_updated(&env, &cid, &mut observed);
+    case_employee_status_changed(&env, &cid, &mut observed);
+    case_registry_pause_manager_set(&env, &cid, &mut observed);
+    case_company_admin_proposed(&env, &cid, &mut observed);
+    case_company_admin_rotated(&env, &cid, &mut observed);
+    case_company_admin_rotation_cancelled(&env, &cid, &mut observed);
+    case_company_treasury_proposed(&env, &cid, &mut observed);
+    case_company_treasury_rotated(&env, &cid, &mut observed);
+    case_company_treasury_rotation_cancelled(&env, &cid, &mut observed);
+
+    assert_matches_fixture(
+        "registry",
+        include_str!("../fixtures/events/registry.json"),
+        observed,
+    );
+}

--- a/tests/event_schema/src/salary_commitment.rs
+++ b/tests/event_schema/src/salary_commitment.rs
@@ -1,0 +1,362 @@
+//! Snapshot coverage for every event emitted by the Salary Commitment
+//! contract (`contracts/events/src/lib.rs`, "Salary Commitment Events"
+//! section).
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, IntoVal, Symbol, TryIntoVal, Val, Vec as SVec};
+
+use crate::support::{
+    assert_matches_fixture, dynamic, field, last_event, new_env, sym, EventSchema, SchemaMap,
+};
+
+fn case_commitment_stored(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let employee = Address::generate(env);
+    let commitment = BytesN::from_array(env, &[20u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_commitment_stored(env, employee.clone(), commitment.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "CommitmentUpdated"), employee.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.CommitmentUpdated topics changed"
+    );
+    let decoded: (BytesN<32>,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (commitment,),
+        "salary_commitment.CommitmentUpdated payload changed"
+    );
+    out.insert(
+        "salary_commitment.CommitmentUpdated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("CommitmentUpdated"), dynamic("Address")],
+            data: vec![field("commitment", "BytesN<32>")],
+        },
+    );
+}
+
+fn case_commitment_rotated(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let employee = Address::generate(env);
+    let old_commitment = BytesN::from_array(env, &[21u8; 32]);
+    let new_commitment = BytesN::from_array(env, &[22u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_commitment_rotated(
+            env,
+            employee.clone(),
+            old_commitment.clone(),
+            new_commitment.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "CommitmentRotated"), employee.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.CommitmentRotated topics changed"
+    );
+    let decoded: (BytesN<32>, BytesN<32>) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (old_commitment, new_commitment),
+        "salary_commitment.CommitmentRotated payload changed"
+    );
+    out.insert(
+        "salary_commitment.CommitmentRotated".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("CommitmentRotated"), dynamic("Address")],
+            data: vec![
+                field("old_commitment", "BytesN<32>"),
+                field("new_commitment", "BytesN<32>"),
+            ],
+        },
+    );
+}
+
+fn case_commitment_locked(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let employee = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_commitment_locked(env, employee.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "CommitmentLocked"), employee.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.CommitmentLocked topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (),
+        "salary_commitment.CommitmentLocked payload changed"
+    );
+    out.insert(
+        "salary_commitment.CommitmentLocked".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("CommitmentLocked"), dynamic("Address")],
+            data: vec![],
+        },
+    );
+}
+
+fn case_commitment_unlocked(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let employee = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_commitment_unlocked(env, employee.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "CommitmentUnlocked"), employee.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.CommitmentUnlocked topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (),
+        "salary_commitment.CommitmentUnlocked payload changed"
+    );
+    out.insert(
+        "salary_commitment.CommitmentUnlocked".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("CommitmentUnlocked"), dynamic("Address")],
+            data: vec![],
+        },
+    );
+}
+
+fn case_reference_id_set(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let employee = Address::generate(env);
+    let reference_id = soroban_sdk::String::from_str(env, "EMP-0042");
+    env.as_contract(cid, || {
+        payroll_events::emit_reference_id_set(env, employee.clone(), reference_id.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "ReferenceIdSet"), employee.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.ReferenceIdSet topics changed"
+    );
+    let decoded: (soroban_sdk::String,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (reference_id,),
+        "salary_commitment.ReferenceIdSet payload changed"
+    );
+    out.insert(
+        "salary_commitment.ReferenceIdSet".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("ReferenceIdSet"), dynamic("Address")],
+            data: vec![field("reference_id", "String")],
+        },
+    );
+}
+
+fn case_nullifier_recorded(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let nullifier = BytesN::from_array(env, &[23u8; 32]);
+    env.as_contract(cid, || {
+        payroll_events::emit_nullifier_recorded(env, nullifier.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "NullifierRecorded"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.NullifierRecorded topics changed"
+    );
+    let decoded: (BytesN<32>,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (nullifier,),
+        "salary_commitment.NullifierRecorded payload changed"
+    );
+    out.insert(
+        "salary_commitment.NullifierRecorded".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("NullifierRecorded")],
+            data: vec![field("nullifier", "BytesN<32>")],
+        },
+    );
+}
+
+fn case_payroll_operator_set(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let operator = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_payroll_operator_set(env, operator.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "PayrollOperatorSet"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.PayrollOperatorSet topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (operator,),
+        "salary_commitment.PayrollOperatorSet payload changed"
+    );
+    out.insert(
+        "salary_commitment.PayrollOperatorSet".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("PayrollOperatorSet")],
+            data: vec![field("operator", "Address")],
+        },
+    );
+}
+
+fn case_commitment_admin_proposed(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let current_admin = Address::generate(env);
+    let new_admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_commitment_admin_proposed(
+            env,
+            current_admin.clone(),
+            new_admin.clone(),
+        );
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "AdminRotationProposed"),
+        current_admin.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.AdminRotationProposed topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (new_admin,),
+        "salary_commitment.AdminRotationProposed payload changed"
+    );
+    out.insert(
+        "salary_commitment.AdminRotationProposed".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("AdminRotationProposed"), dynamic("Address")],
+            data: vec![field("new_admin", "Address")],
+        },
+    );
+}
+
+fn case_commitment_admin_accepted(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let new_admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_commitment_admin_accepted(env, new_admin.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> =
+        (Symbol::new(env, "AdminRotationAccepted"), new_admin.clone()).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.AdminRotationAccepted topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (),
+        "salary_commitment.AdminRotationAccepted payload changed"
+    );
+    out.insert(
+        "salary_commitment.AdminRotationAccepted".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("AdminRotationAccepted"), dynamic("Address")],
+            data: vec![],
+        },
+    );
+}
+
+fn case_commitment_admin_cancelled(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let current_admin = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_commitment_admin_cancelled(env, current_admin.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (
+        Symbol::new(env, "AdminRotationCancelled"),
+        current_admin.clone(),
+    )
+        .into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.AdminRotationCancelled topics changed"
+    );
+    let decoded: () = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (),
+        "salary_commitment.AdminRotationCancelled payload changed"
+    );
+    out.insert(
+        "salary_commitment.AdminRotationCancelled".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("AdminRotationCancelled"), dynamic("Address")],
+            data: vec![],
+        },
+    );
+}
+
+fn case_commitment_pause_manager_set(env: &Env, cid: &Address, out: &mut SchemaMap) {
+    let pause_manager = Address::generate(env);
+    env.as_contract(cid, || {
+        payroll_events::emit_commitment_pause_manager_set(env, pause_manager.clone());
+    });
+    let (_, topics, data) = last_event(env);
+    let expected_topics: SVec<Val> = (Symbol::new(env, "CommitPauseMgrSet"),).into_val(env);
+    assert_eq!(
+        topics, expected_topics,
+        "salary_commitment.CommitPauseMgrSet topics changed"
+    );
+    let decoded: (Address,) = data.try_into_val(env).unwrap();
+    assert_eq!(
+        decoded,
+        (pause_manager,),
+        "salary_commitment.CommitPauseMgrSet payload changed"
+    );
+    out.insert(
+        "salary_commitment.CommitPauseMgrSet".to_string(),
+        EventSchema {
+            schema_version: 1,
+            topics: vec![sym("CommitPauseMgrSet")],
+            data: vec![field("pause_manager", "Address")],
+        },
+    );
+}
+
+#[test]
+fn salary_commitment_events_match_fixture() {
+    let (env, cid) = new_env();
+    let mut observed = SchemaMap::new();
+
+    case_commitment_stored(&env, &cid, &mut observed);
+    case_commitment_rotated(&env, &cid, &mut observed);
+    case_commitment_locked(&env, &cid, &mut observed);
+    case_commitment_unlocked(&env, &cid, &mut observed);
+    case_reference_id_set(&env, &cid, &mut observed);
+    case_nullifier_recorded(&env, &cid, &mut observed);
+    case_payroll_operator_set(&env, &cid, &mut observed);
+    case_commitment_admin_proposed(&env, &cid, &mut observed);
+    case_commitment_admin_accepted(&env, &cid, &mut observed);
+    case_commitment_admin_cancelled(&env, &cid, &mut observed);
+    case_commitment_pause_manager_set(&env, &cid, &mut observed);
+
+    assert_matches_fixture(
+        "salary_commitment",
+        include_str!("../fixtures/events/salary_commitment.json"),
+        observed,
+    );
+}

--- a/tests/event_schema/src/support.rs
+++ b/tests/event_schema/src/support.rs
@@ -1,0 +1,124 @@
+//! Shared scaffolding for the event schema snapshot tests.
+//!
+//! Each contract event is captured twice, structurally:
+//! - **topics**, compared as a whole `soroban_sdk::Vec<Val>` against the
+//!   exact tuple the emitter publishes, so any reordering, insertion, or type
+//!   change in the topic list fails the test immediately.
+//! - **data**, decoded into the exact Rust tuple/type the emitter constructs
+//!   and compared field-for-field, so a payload shape change (added/removed
+//!   field, reordered field, retyped field) fails to decode or fails the
+//!   `assert_eq!`.
+//!
+//! On top of that structural check, each event also produces an [`EventSchema`]
+//! description (topic kinds + payload field names/types + a schema version)
+//! that is compared against a checked-in fixture in `fixtures/events/`. The
+//! fixture is what reviewers actually diff in a pull request, and what a
+//! consumer team can point to as the contract for a given event. See
+//! `fixtures/events/README.md` for the intentional-migration process.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use soroban_sdk::testutils::Events;
+use soroban_sdk::{contract, contractimpl, Address, Env, Val, Vec as SVec};
+
+/// A no-op contract whose only purpose is to give `as_contract` a real,
+/// registered contract instance to publish events under. `payroll_events`
+/// helpers are free functions, not contract entrypoints, so tests invoke
+/// them directly rather than through this contract's (empty) interface.
+#[contract]
+pub struct EventProbe;
+
+#[contractimpl]
+impl EventProbe {}
+
+/// One topic slot in an event's topic list.
+///
+/// `Symbol` topics carry a fixed `value` (the domain/action name is part of
+/// the contract, so it is asserted verbatim). Topics that carry a
+/// per-invocation identifier (an `Address`, a `u64` id, ...) only pin the
+/// *type*, since the value is naturally dynamic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TopicSpec {
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+pub fn sym(value: &str) -> TopicSpec {
+    TopicSpec {
+        ty: "Symbol".to_string(),
+        value: Some(value.to_string()),
+    }
+}
+
+pub fn dynamic(ty: &str) -> TopicSpec {
+    TopicSpec {
+        ty: ty.to_string(),
+        value: None,
+    }
+}
+
+/// One field in an event's data payload. Soroban events carry payload fields
+/// positionally (there are no on-the-wire field names), so `name` here is
+/// documentation for SDK/indexer authors, while `type` is what the snapshot
+/// actually enforces via the decode step in each test.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FieldSpec {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: String,
+}
+
+pub fn field(name: &str, ty: &str) -> FieldSpec {
+    FieldSpec {
+        name: name.to_string(),
+        ty: ty.to_string(),
+    }
+}
+
+/// The full schema description for one event, as recorded in a fixture file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EventSchema {
+    pub schema_version: u32,
+    pub topics: Vec<TopicSpec>,
+    pub data: Vec<FieldSpec>,
+}
+
+/// Fixture files map `"<contract>.<event>"` to its [`EventSchema`]. A map
+/// (rather than an ordered list) is used so that adding a new event, or
+/// reordering the test functions that produce them, never causes a spurious
+/// diff for events that did not change.
+pub type SchemaMap = BTreeMap<String, EventSchema>;
+
+/// A fresh, isolated `Env` plus a synthetic contract id to publish events
+/// under (`payroll_events` helpers require an active contract frame).
+pub fn new_env() -> (Env, Address) {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EventProbe);
+    (env, contract_id)
+}
+
+/// Returns the most recently published event as `(contract, topics, data)`.
+pub fn last_event(env: &Env) -> (Address, SVec<Val>, Val) {
+    let all = env.events().all();
+    let len = all.len();
+    assert!(len > 0, "expected an event to have been published");
+    all.get(len - 1).unwrap()
+}
+
+/// Compares the schemas observed in this test run against the checked-in
+/// fixture, with a failure message that points at the migration doc instead
+/// of a bare `assert_eq!`.
+pub fn assert_matches_fixture(fixture_name: &str, fixture_json: &str, observed: SchemaMap) {
+    let expected: SchemaMap = serde_json::from_str(fixture_json)
+        .unwrap_or_else(|err| panic!("fixtures/events/{fixture_name}.json failed to parse: {err}"));
+    assert_eq!(
+        observed, expected,
+        "\n\nEvent schema drift detected against fixtures/events/{fixture_name}.json.\n\
+         If this is an intentional schema change: bump `schema_version` for the\n\
+         affected event(s), update the fixture, and record the migration per\n\
+         fixtures/events/README.md before merging.\n"
+    );
+}


### PR DESCRIPTION
closes #341

Pin the topic and payload shape of every event emitted through payroll_events (73 events across Payroll, Payroll Registry, Salary Commitment, Payment Executor, Pause Manager, and Audit Module) with snapshot tests in a new event_schema_snapshots workspace crate.

Each event is captured by invoking the real emit_* helper, asserting the published topics/data structurally against the exact values constructed, and diffing a versioned schema description against a checked-in fixture in tests/event_schema/fixtures/events/. A topic reorder, payload field change, or type change fails loudly instead of silently breaking SDK, dashboard, or audit-export consumers. fixtures/events/README.md documents the intentional-migration process and schema_version bump.

## Summary

<!-- Provide a concise description of what this PR does and why.
     Link the related issue(s) below. -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] ZK circuit change (requires new trusted setup / ptau ceremony)
- [ ] Refactor (no functional changes)
- [ ] Documentation / comments only
- [ ] CI/CD or tooling change

## Description of Changes

<!-- List the key changes made in this PR. For contract changes, describe
     the affected entry-points and storage slots. For circuit changes,
     describe which signals / constraints were modified. -->

-
-
-

---

## Checklist

### General

- [ ] My code follows the project's Rust style guidelines (`cargo fmt --check` passes)
- [ ] I have performed a self-review of my own code
- [ ] I have added comments for any non-obvious logic
- [ ] I have updated relevant documentation (`README.md`, `CONTRIBUTING.md`, inline docs)
- [ ] My changes do not introduce new compiler warnings (`cargo clippy` passes)
- [ ] I have added tests that cover my changes
- [ ] All existing tests pass locally (`cargo test`)

### Smart Contracts (if applicable)

- [ ] I have measured and documented gas / resource usage for new or changed entry-points
  - CPU instructions (before / after):
  - Memory bytes (before / after):
  - Ledger entries read/written (before / after):
  - Estimated XLM fee (before / after):
- [ ] I have verified there are no storage layout regressions (state rent impact assessed)
- [ ] I have checked for integer overflow / underflow and used checked arithmetic
- [ ] Authorization checks (`require_auth`, `require_auth_for_args`) are correct and tested
- [ ] No sensitive data (salaries, blinding factors, private keys) is emitted in events or exposed in storage

### ZK Circuits (if applicable)

- [ ] Circuit compiles without errors: `circom <circuit>.circom --r1cs --wasm --sym`
- [ ] Witness generation succeeds for test inputs
- [ ] Proof generation and verification pass end-to-end
- [ ] New trusted setup (phase 2 ptau) is required: **Yes / No**
  - If yes, link to the ceremony artifacts:
- [ ] Constraint count change documented:
  - Before: <!-- n constraints -->
  - After:  <!-- n constraints -->
- [ ] Verifier Solidity/Rust contract regenerated (if verifying key changed)

### Security

- [ ] I have considered potential attack vectors relevant to this change
  - [ ] Re-entrancy (not applicable on Soroban, but noted for audit completeness)
  - [ ] Front-running / MEV risks
  - [ ] Proof malleability (for ZK changes)
  - [ ] Commitment binding / hiding properties preserved (for commitment changes)
- [ ] No hardcoded secrets, keys, or sensitive configuration values in code
- [ ] Dependencies added/updated have been reviewed for known vulnerabilities (`cargo audit`)

---

## Testing Evidence

<!-- Paste relevant test output or describe manual testing steps performed. -->

```
cargo test output:
```

## Additional Notes

<!-- Any other context reviewers should know: deployment steps, migration
     scripts, known limitations, follow-up issues, etc. -->
