### PR TITLE
feat(payroll): add dispute freeze and thaw controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispute_tests"
+version = "0.1.0"
+dependencies = [
+ "payroll",
+ "proof_verifier",
+ "salary_commitment",
+ "soroban-sdk",
+ "token",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "tests/storage",
     "tests/access-control",
     "tests/events",
+    "tests/disputes",
 ]
 exclude = ["fuzz"]
 

--- a/contracts/events/src/lib.rs
+++ b/contracts/events/src/lib.rs
@@ -786,7 +786,10 @@ pub fn emit_audit_pause_manager_set(e: &Env, pause_manager: Address) {
 /// Emitted when locked payroll funds are updated (#343).
 pub fn emit_locked_funds_updated(e: &Env, asset: Address, locked_amount: i128) {
     e.events().publish(
-        (Symbol::new(e, "treasury"), Symbol::new(e, "locked_funds_updated")),
+        (
+            Symbol::new(e, "treasury"),
+            Symbol::new(e, "locked_funds_updated"),
+        ),
         (asset, locked_amount),
     );
 }

--- a/contracts/events/src/lib.rs
+++ b/contracts/events/src/lib.rs
@@ -292,6 +292,61 @@ pub fn emit_run_changes_requested(e: &Env, run_id: u64, reviewer: Address, reaso
     );
 }
 
+/// Emitted when a payroll run's archived on-chain record is permanently pruned (#342).
+pub fn emit_run_pruned(e: &Env, run_id: u64, admin: Address) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "run_pruned")),
+        (run_id, admin),
+    );
+}
+
+/// Emitted when an address is granted dispute-authority permission (#342).
+pub fn emit_dispute_authority_added(e: &Env, authority: Address) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "dispute_auth_added")),
+        authority,
+    );
+}
+
+/// Emitted when an address has dispute-authority permission revoked (#342).
+pub fn emit_dispute_authority_removed(e: &Env, authority: Address) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "dispute_auth_removed")),
+        authority,
+    );
+}
+
+/// Emitted when a dispute is opened against a payroll run, freezing its
+/// finalization, archival, and pruning (#342).
+pub fn emit_dispute_opened(
+    e: &Env,
+    dispute_id: u64,
+    run_id: u64,
+    opened_by: Address,
+    period: Symbol,
+    batch_root: BytesN<32>,
+    reason: Symbol,
+) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "dispute_opened")),
+        (dispute_id, run_id, opened_by, period, batch_root, reason),
+    );
+}
+
+/// Emitted when an active dispute is resolved, thawing the associated run (#342).
+pub fn emit_dispute_resolved(
+    e: &Env,
+    dispute_id: u64,
+    run_id: u64,
+    resolved_by: Address,
+    resolution_reason: Symbol,
+) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "dispute_resolved")),
+        (dispute_id, run_id, resolved_by, resolution_reason),
+    );
+}
+
 // ═════════════════════════════════════════════════════════════════════════════
 // Payroll Registry Events
 // ═════════════════════════════════════════════════════════════════════════════

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -176,6 +176,39 @@ pub struct RunReview {
     pub reviewed_at: u64,
 }
 
+// ── Issue #342: dispute freeze/thaw controls ─────────────────────────────────
+
+/// Lifecycle status of a payroll dispute.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DisputeStatus {
+    Active = 0,
+    Resolved = 1,
+}
+
+/// A payroll dispute record scoped to an employer, period, and batch root.
+///
+/// While `status` is `Active`, the associated payroll run is frozen: it
+/// cannot be finalized, archived, or pruned. Only the admin or an address
+/// granted the dispute-authority role may open or resolve a dispute.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Dispute {
+    pub dispute_id: u64,
+    pub run_id: u64,
+    pub employer: Address,
+    pub period: Symbol,
+    pub batch_root: BytesN<32>,
+    pub opened_by: Address,
+    pub opened_at: u64,
+    pub open_reason: Symbol,
+    pub status: DisputeStatus,
+    pub resolved_by: Option<Address>,
+    pub resolved_at: Option<u64>,
+    pub resolution_reason: Option<Symbol>,
+}
+
 // ── Issue #91: privileged-role rotation ──────────────────────────────────────
 
 /// Pending two-step role-rotation request.
@@ -337,6 +370,14 @@ pub enum DataKey {
     AuthorizedReviewer(Address),
     /// Review record for a payroll run.
     RunReview(u64),
+    /// Auto-increment counter for dispute IDs (#342).
+    DisputeCounter,
+    /// Dispute record scoped to employer, period, and batch root (#342).
+    Dispute(u64),
+    /// Marks the id of the active dispute freezing a given run, if any (#342).
+    ActiveDisputeForRun(u64),
+    /// Authorized dispute-resolution role registration (#342).
+    DisputeAuthority(Address),
     // Future upgrade example (issue #196):
     // PayrollRunV2(u64),  // Would be added here when schema evolution is needed
 }
@@ -1069,6 +1110,7 @@ impl Payroll {
     pub fn finalize_payroll_run(e: Env, admin: Address, run_id: u64) {
         Self::require_not_paused(&e);
         Self::validate_run_id(run_id);
+        Self::require_run_not_disputed(&e, run_id);
         let addrs: ContractAddresses = e
             .storage()
             .persistent()
@@ -1941,6 +1983,7 @@ impl Payroll {
     /// cannot trigger execution, state transitions, or treasury mutations.
     pub fn archive_payroll_run(e: Env, admin: Address, run_id: u64) {
         Self::validate_run_id(run_id);
+        Self::require_run_not_disputed(&e, run_id);
         let addrs: ContractAddresses = e
             .storage()
             .persistent()
@@ -1988,6 +2031,252 @@ impl Payroll {
     pub fn is_run_archived(e: Env, run_id: u64) -> bool {
         Self::validate_run_id(run_id);
         e.storage().persistent().has(&DataKey::ArchivedRun(run_id))
+    }
+
+    /// Permanently remove an archived payroll run's on-chain record once its
+    /// retention window has been satisfied off-chain (issue #342).
+    ///
+    /// This is an irreversible cleanup action. It requires the run to have
+    /// already been archived, and is blocked while the run has an active
+    /// dispute, mirroring the guards on `finalize_payroll_run` and
+    /// `archive_payroll_run`.
+    pub fn prune_payroll_run(e: Env, admin: Address, run_id: u64) {
+        Self::validate_run_id(run_id);
+        Self::require_run_not_disputed(&e, run_id);
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+
+        if !e.storage().persistent().has(&DataKey::ArchivedRun(run_id)) {
+            panic!("Run must be archived before it can be pruned");
+        }
+
+        e.storage()
+            .persistent()
+            .remove(&DataKey::PayrollRun(run_id));
+        e.storage()
+            .persistent()
+            .remove(&DataKey::ArchivedRun(run_id));
+
+        payroll_events::emit_run_pruned(&e, run_id, admin);
+    }
+
+    // ── Issue #342: dispute freeze/thaw controls ─────────────────────────────
+
+    /// Grant dispute-authority permission to an address. Only the admin may call.
+    ///
+    /// Dispute authorities may open and resolve disputes in addition to the
+    /// admin, who always implicitly holds this permission.
+    pub fn add_dispute_authority(e: Env, admin: Address, authority: Address) {
+        Self::require_not_paused(&e);
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+
+        e.storage()
+            .persistent()
+            .set(&DataKey::DisputeAuthority(authority.clone()), &true);
+
+        payroll_events::emit_dispute_authority_added(&e, authority);
+    }
+
+    /// Revoke dispute-authority permission from an address. Only the admin may call.
+    pub fn remove_dispute_authority(e: Env, admin: Address, authority: Address) {
+        Self::require_not_paused(&e);
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+
+        e.storage()
+            .persistent()
+            .remove(&DataKey::DisputeAuthority(authority.clone()));
+
+        payroll_events::emit_dispute_authority_removed(&e, authority);
+    }
+
+    /// Return `true` if the address may open or resolve disputes: the
+    /// contract admin, or an address explicitly granted dispute authority.
+    pub fn is_dispute_authority(e: Env, address: Address) -> bool {
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if address == addrs.admin {
+            return true;
+        }
+        e.storage()
+            .persistent()
+            .get(&DataKey::DisputeAuthority(address))
+            .unwrap_or(false)
+    }
+
+    fn require_dispute_authority(e: &Env, caller: &Address) {
+        if !Self::is_dispute_authority(e.clone(), caller.clone()) {
+            panic!("Unauthorized: caller is not an authorized dispute authority");
+        }
+    }
+
+    /// Panic if `run_id` has an active dispute. Called by every irreversible
+    /// lifecycle action (finalize, archive, prune) to enforce the freeze.
+    fn require_run_not_disputed(e: &Env, run_id: u64) {
+        if e.storage()
+            .persistent()
+            .has(&DataKey::ActiveDisputeForRun(run_id))
+        {
+            panic!("Run is under active dispute");
+        }
+    }
+
+    /// Open a dispute against a payroll run, freezing finalization, archival,
+    /// and pruning until the dispute is resolved (issue #342).
+    ///
+    /// Only the admin or an authorized dispute authority may open a dispute.
+    /// The dispute record is scoped to the employer (contract admin), the
+    /// caller-supplied period label, and the batch root committed for the
+    /// disputed run, giving auditors a stable reference for the freeze.
+    pub fn open_dispute(
+        e: Env,
+        caller: Address,
+        run_id: u64,
+        period: Symbol,
+        batch_root: BytesN<32>,
+        reason: Symbol,
+    ) -> u64 {
+        Self::validate_run_id(run_id);
+        Self::validate_symbol_not_empty(&e, &period, "period");
+        Self::validate_non_zero_digest(&e, &batch_root, "batch_root");
+        Self::validate_symbol_not_empty(&e, &reason, "reason");
+        Self::require_dispute_authority(&e, &caller);
+        caller.require_auth();
+
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+
+        // The run must exist, either pending finalization or already executed.
+        if !e.storage().persistent().has(&DataKey::PayrollRun(run_id))
+            && !e.storage().persistent().has(&DataKey::PendingRun(run_id))
+        {
+            panic!("Run not found");
+        }
+
+        if e.storage()
+            .persistent()
+            .has(&DataKey::ActiveDisputeForRun(run_id))
+        {
+            panic!("Run already has an active dispute");
+        }
+
+        let dispute_id = e
+            .storage()
+            .persistent()
+            .get(&DataKey::DisputeCounter)
+            .unwrap_or(0u64)
+            + 1;
+        e.storage()
+            .persistent()
+            .set(&DataKey::DisputeCounter, &dispute_id);
+
+        let dispute = Dispute {
+            dispute_id,
+            run_id,
+            employer: addrs.admin,
+            period: period.clone(),
+            batch_root: batch_root.clone(),
+            opened_by: caller.clone(),
+            opened_at: e.ledger().timestamp(),
+            open_reason: reason.clone(),
+            status: DisputeStatus::Active,
+            resolved_by: None,
+            resolved_at: None,
+            resolution_reason: None,
+        };
+        e.storage()
+            .persistent()
+            .set(&DataKey::Dispute(dispute_id), &dispute);
+        e.storage()
+            .persistent()
+            .set(&DataKey::ActiveDisputeForRun(run_id), &dispute_id);
+
+        payroll_events::emit_dispute_opened(
+            &e, dispute_id, run_id, caller, period, batch_root, reason,
+        );
+
+        dispute_id
+    }
+
+    /// Resolve (thaw) an active dispute with a reason code (issue #342).
+    ///
+    /// Only the admin or an authorized dispute authority may resolve a
+    /// dispute. Once resolved, the associated run is no longer frozen and
+    /// normal lifecycle actions (finalize, archive, prune) may continue.
+    pub fn resolve_dispute(e: Env, caller: Address, dispute_id: u64, resolution_reason: Symbol) {
+        Self::validate_symbol_not_empty(&e, &resolution_reason, "resolution_reason");
+        Self::require_dispute_authority(&e, &caller);
+        caller.require_auth();
+
+        let key = DataKey::Dispute(dispute_id);
+        let mut dispute: Dispute = e
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Dispute not found");
+        if dispute.status != DisputeStatus::Active {
+            panic!("Dispute is not active");
+        }
+
+        dispute.status = DisputeStatus::Resolved;
+        dispute.resolved_by = Some(caller.clone());
+        dispute.resolved_at = Some(e.ledger().timestamp());
+        dispute.resolution_reason = Some(resolution_reason.clone());
+        e.storage().persistent().set(&key, &dispute);
+        e.storage()
+            .persistent()
+            .remove(&DataKey::ActiveDisputeForRun(dispute.run_id));
+
+        payroll_events::emit_dispute_resolved(
+            &e,
+            dispute_id,
+            dispute.run_id,
+            caller,
+            resolution_reason,
+        );
+    }
+
+    /// Return the dispute record for the given dispute id.
+    pub fn get_dispute(e: Env, dispute_id: u64) -> Dispute {
+        e.storage()
+            .persistent()
+            .get(&DataKey::Dispute(dispute_id))
+            .expect("Dispute not found")
+    }
+
+    /// Return `true` if the run currently has an active dispute, `false` otherwise.
+    pub fn is_run_disputed(e: Env, run_id: u64) -> bool {
+        e.storage()
+            .persistent()
+            .has(&DataKey::ActiveDisputeForRun(run_id))
     }
 
     // ── Reviewer Authorization & Run Review Entrypoints ─────────────────────

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
+use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token as soroban_token, Address, BytesN,
     Env, Symbol, Vec,
 };
-use soroban_sdk::xdr::ToXdr;
 
 use pause_manager::PauseManagerClient;
 use proof_verifier::ProofVerifierClient;
@@ -2103,7 +2103,9 @@ impl Payroll {
 
     /// Check if a quorum approval payload hash has already been consumed.
     pub fn is_quorum_consumed(e: Env, quorum_hash: BytesN<32>) -> bool {
-        e.storage().persistent().has(&DataKey::ConsumedQuorum(quorum_hash))
+        e.storage()
+            .persistent()
+            .has(&DataKey::ConsumedQuorum(quorum_hash))
     }
 
     /// Verify signer quorum requirements and consume the quorum approval reference once.
@@ -2140,11 +2142,17 @@ impl Payroll {
             panic!("Quorum approval payload already consumed: replay rejected");
         }
 
-        e.storage()
-            .persistent()
-            .set(&DataKey::ConsumedQuorum(q_hash.clone()), &e.ledger().timestamp());
+        e.storage().persistent().set(
+            &DataKey::ConsumedQuorum(q_hash.clone()),
+            &e.ledger().timestamp(),
+        );
 
-        payroll_events::emit_quorum_consumed(&e, payload.batch_root, payload.employer, payload.nonce);
+        payroll_events::emit_quorum_consumed(
+            &e,
+            payload.batch_root,
+            payload.employer,
+            payload.nonce,
+        );
         q_hash
     }
 
@@ -5152,7 +5160,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Insufficient available treasury balance: funds locked for pending payroll")]
+    #[should_panic(
+        expected = "Insufficient available treasury balance: funds locked for pending payroll"
+    )]
     fn test_withdrawal_guardrails_rejects_underfunding() {
         let env = Env::default();
         let (payroll_client, _admin, treasury, treasury_owner, employee, token_id) =

--- a/tests/access-control/admin_handover.rs
+++ b/tests/access-control/admin_handover.rs
@@ -82,12 +82,8 @@ fn test_admin_handover_success_and_role_transfer() {
     assert!(client.get_pending_admin_handover().is_none());
 
     // Verify new admin can perform admin operations
-    let draft_id = client.create_run_draft(
-        &pending_admin,
-        &10_000i128,
-        &5u32,
-        &Symbol::new(&env, "Q1"),
-    );
+    let draft_id =
+        client.create_run_draft(&pending_admin, &10_000i128, &5u32, &Symbol::new(&env, "Q1"));
     assert_eq!(draft_id, 1);
 }
 

--- a/tests/access-control/withdrawal_guardrails.rs
+++ b/tests/access-control/withdrawal_guardrails.rs
@@ -35,7 +35,16 @@ fn test_nonce(env: &Env, seed: u8) -> BytesN<32> {
     BytesN::from_array(env, &arr)
 }
 
-fn setup_payroll(env: &Env) -> (PayrollClient<'_>, Address, Address, Address, Address, Address) {
+fn setup_payroll(
+    env: &Env,
+) -> (
+    PayrollClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     env.mock_all_auths();
 
     let verifier_id = env.register_contract(None, ProofVerifier);
@@ -74,7 +83,14 @@ fn setup_payroll(env: &Env) -> (PayrollClient<'_>, Address, Address, Address, Ad
     let employee = Address::generate(env);
     commitment_client.store_commitment(&employee, &BytesN::from_array(env, &[0u8; 32]));
 
-    (payroll_client, admin, treasury, treasury_owner, employee, token_id)
+    (
+        payroll_client,
+        admin,
+        treasury,
+        treasury_owner,
+        employee,
+        token_id,
+    )
 }
 
 #[test]
@@ -87,7 +103,10 @@ fn test_withdrawal_before_lock_and_after_cancellation() {
 
     // Initial state: locked funds = 0, available = total_balance
     assert_eq!(client.get_locked_funds(&token_id), 0);
-    assert_eq!(client.get_available_treasury_balance(&token_id), total_balance);
+    assert_eq!(
+        client.get_available_treasury_balance(&token_id),
+        total_balance
+    );
 
     // Prepare payroll run locking 50,000
     let mut proofs = Vec::new(&env);
@@ -127,7 +146,9 @@ fn test_withdrawal_before_lock_and_after_cancellation() {
 }
 
 #[test]
-#[should_panic(expected = "Insufficient available treasury balance: funds locked for pending payroll")]
+#[should_panic(
+    expected = "Insufficient available treasury balance: funds locked for pending payroll"
+)]
 fn test_withdrawal_attempt_exceeding_surplus_rejected() {
     let env = Env::default();
     let (client, _admin, treasury, treasury_owner, employee, token_id) = setup_payroll(&env);

--- a/tests/disputes/Cargo.toml
+++ b/tests/disputes/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "dispute_tests"
+version.workspace = true
+edition.workspace = true
+
+[[test]]
+name = "dispute_freeze"
+path = "dispute_freeze.rs"
+
+[dev-dependencies]
+payroll = { path = "../../contracts/payroll" }
+proof_verifier = { path = "../../contracts/proof_verifier" }
+salary_commitment = { path = "../../contracts/salary_commitment" }
+token = { path = "../../contracts/token" }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/tests/disputes/dispute_freeze.rs
+++ b/tests/disputes/dispute_freeze.rs
@@ -1,0 +1,480 @@
+//! Dispute Freeze and Thaw Control Tests (issue #342)
+//!
+//! Verifies that an active payroll dispute freezes irreversible lifecycle
+//! actions (finalize, archive, prune) for the disputed run, that only
+//! authorized roles (the admin or an explicitly granted dispute authority)
+//! may open or resolve disputes, and that a resolved dispute allows normal
+//! lifecycle continuation.
+
+use payroll::{DisputeStatus, Payroll, PayrollClient};
+use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
+use salary_commitment::{SalaryCommitmentContract, SalaryCommitmentContractClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+use token::{Token, TokenClient};
+
+fn mock_vk(env: &Env) -> VerificationKey {
+    VerificationKey {
+        alpha: BytesN::from_array(env, &[0u8; 64]),
+        beta: BytesN::from_array(env, &[0u8; 128]),
+        gamma: BytesN::from_array(env, &[0u8; 128]),
+        delta: BytesN::from_array(env, &[0u8; 128]),
+        ic: Vec::from_array(
+            env,
+            [
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+            ],
+        ),
+    }
+}
+
+fn mock_proof(env: &Env) -> BytesN<256> {
+    BytesN::from_array(env, &[1u8; 256])
+}
+
+fn test_nonce(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    bytes[31] = 0xAA;
+    BytesN::from_array(env, &bytes)
+}
+
+fn batch_root(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    bytes[1] = 0xEE;
+    BytesN::from_array(env, &bytes)
+}
+
+struct TestContext<'a> {
+    env: Env,
+    payroll_client: PayrollClient<'a>,
+    admin: Address,
+    employee: Address,
+}
+
+fn setup_test_context() -> TestContext<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let verifier_id = env.register_contract(None, ProofVerifier);
+    let verifier_client = ProofVerifierClient::new(&env, &verifier_id);
+    let verifier_admin = Address::generate(&env);
+    verifier_client.init_verifier_admin(&verifier_admin);
+    verifier_client.initialize_verifier(&mock_vk(&env));
+
+    let commitment_id = env.register_contract(None, SalaryCommitmentContract);
+    let commitment_client = SalaryCommitmentContractClient::new(&env, &commitment_id);
+    let commitment_admin = Address::generate(&env);
+    commitment_client.init_commitment_admin(&commitment_admin);
+
+    let token_id = env.register_contract(None, Token);
+    let token_client = TokenClient::new(&env, &token_id);
+
+    let payroll_id = env.register_contract(None, Payroll);
+    let payroll_client = PayrollClient::new(&env, &payroll_id);
+
+    let treasury = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let treasury_owner = Address::generate(&env);
+
+    token_client.mint(&treasury, &10_000_000i128);
+
+    payroll_client.initialize(
+        &admin,
+        &token_id,
+        &verifier_id,
+        &commitment_id,
+        &treasury,
+        &treasury_owner,
+    );
+
+    commitment_client.set_payroll_operator(&payroll_id);
+
+    let employee = Address::generate(&env);
+    commitment_client.store_commitment(&employee, &BytesN::from_array(&env, &[0x42u8; 32]));
+
+    TestContext {
+        env,
+        payroll_client,
+        admin,
+        employee,
+    }
+}
+
+fn single_payment_batch(
+    env: &Env,
+    employee: &Address,
+    amount: i128,
+) -> (Vec<BytesN<256>>, Vec<i128>, Vec<Address>) {
+    let mut proofs = Vec::new(env);
+    proofs.push_back(mock_proof(env));
+    let mut amounts = Vec::new(env);
+    amounts.push_back(amount);
+    let mut employees = Vec::new(env);
+    employees.push_back(employee.clone());
+    (proofs, amounts, employees)
+}
+
+/// Prepares a pending run and returns its run_id.
+fn prepare_run(ctx: &TestContext, seed: u8, amount: i128) -> u64 {
+    let (proofs, amounts, employees) = single_payment_batch(&ctx.env, &ctx.employee, amount);
+    let nonce = test_nonce(&ctx.env, seed);
+    ctx.payroll_client
+        .prepare_payroll_run(&proofs, &amounts, &employees, &amount, &nonce, &None)
+}
+
+// ── Freeze: active disputes block irreversible lifecycle actions ───────────
+
+#[test]
+fn test_active_dispute_blocks_finalization() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 1, 10_000i128);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 1);
+    let reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    ctx.payroll_client
+        .open_dispute(&ctx.admin, &run_id, &period, &root, &reason);
+
+    assert!(ctx.payroll_client.is_run_disputed(&run_id));
+
+    let result = ctx
+        .payroll_client
+        .try_finalize_payroll_run(&ctx.admin, &run_id);
+    assert!(result.is_err(), "Finalizing a disputed run must fail");
+}
+
+#[test]
+fn test_active_dispute_blocks_archival() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 2, 10_000i128);
+    ctx.payroll_client.finalize_payroll_run(&ctx.admin, &run_id);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 2);
+    let reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    ctx.payroll_client
+        .open_dispute(&ctx.admin, &run_id, &period, &root, &reason);
+
+    let result = ctx
+        .payroll_client
+        .try_archive_payroll_run(&ctx.admin, &run_id);
+    assert!(result.is_err(), "Archiving a disputed run must fail");
+}
+
+#[test]
+fn test_active_dispute_blocks_pruning() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 3, 10_000i128);
+    ctx.payroll_client.finalize_payroll_run(&ctx.admin, &run_id);
+    ctx.payroll_client.archive_payroll_run(&ctx.admin, &run_id);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 3);
+    let reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    ctx.payroll_client
+        .open_dispute(&ctx.admin, &run_id, &period, &root, &reason);
+
+    let result = ctx
+        .payroll_client
+        .try_prune_payroll_run(&ctx.admin, &run_id);
+    assert!(result.is_err(), "Pruning a disputed run must fail");
+}
+
+#[test]
+fn test_pruning_requires_archived_run() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 4, 10_000i128);
+    ctx.payroll_client.finalize_payroll_run(&ctx.admin, &run_id);
+
+    // Not yet archived, so pruning must fail even without a dispute.
+    let result = ctx
+        .payroll_client
+        .try_prune_payroll_run(&ctx.admin, &run_id);
+    assert!(
+        result.is_err(),
+        "Pruning a non-archived run must fail regardless of dispute state"
+    );
+}
+
+// ── Thaw: resolved disputes allow normal lifecycle continuation ────────────
+
+#[test]
+fn test_resolved_dispute_allows_finalization() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 5, 10_000i128);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 5);
+    let open_reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    let dispute_id =
+        ctx.payroll_client
+            .open_dispute(&ctx.admin, &run_id, &period, &root, &open_reason);
+
+    let resolution_reason = Symbol::new(&ctx.env, "VERIFIED_OK");
+    ctx.payroll_client
+        .resolve_dispute(&ctx.admin, &dispute_id, &resolution_reason);
+
+    assert!(!ctx.payroll_client.is_run_disputed(&run_id));
+
+    // Finalization now proceeds normally.
+    ctx.payroll_client.finalize_payroll_run(&ctx.admin, &run_id);
+    let run = ctx.payroll_client.get_payroll_run(&run_id);
+    assert_eq!(run.run_id, run_id);
+}
+
+#[test]
+fn test_resolved_dispute_allows_archive_and_prune() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 6, 10_000i128);
+    ctx.payroll_client.finalize_payroll_run(&ctx.admin, &run_id);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 6);
+    let open_reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    let dispute_id =
+        ctx.payroll_client
+            .open_dispute(&ctx.admin, &run_id, &period, &root, &open_reason);
+
+    let resolution_reason = Symbol::new(&ctx.env, "VERIFIED_OK");
+    ctx.payroll_client
+        .resolve_dispute(&ctx.admin, &dispute_id, &resolution_reason);
+
+    ctx.payroll_client.archive_payroll_run(&ctx.admin, &run_id);
+    assert!(ctx.payroll_client.is_run_archived(&run_id));
+
+    ctx.payroll_client.prune_payroll_run(&ctx.admin, &run_id);
+    assert!(!ctx.payroll_client.is_run_archived(&run_id));
+}
+
+#[test]
+fn test_dispute_record_scoped_to_employer_period_and_batch_root() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 7, 10_000i128);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_02");
+    let root = batch_root(&ctx.env, 7);
+    let reason = Symbol::new(&ctx.env, "AMOUNT_MISMATCH");
+    let dispute_id = ctx
+        .payroll_client
+        .open_dispute(&ctx.admin, &run_id, &period, &root, &reason);
+
+    let dispute = ctx.payroll_client.get_dispute(&dispute_id);
+    assert_eq!(dispute.run_id, run_id);
+    assert_eq!(dispute.employer, ctx.admin);
+    assert_eq!(dispute.period, period);
+    assert_eq!(dispute.batch_root, root);
+    assert_eq!(dispute.open_reason, reason);
+    assert_eq!(dispute.status, DisputeStatus::Active);
+    assert!(dispute.resolved_by.is_none());
+}
+
+#[test]
+fn test_resolve_dispute_records_resolver_and_reason() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 8, 10_000i128);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_02");
+    let root = batch_root(&ctx.env, 8);
+    let open_reason = Symbol::new(&ctx.env, "AMOUNT_MISMATCH");
+    let dispute_id =
+        ctx.payroll_client
+            .open_dispute(&ctx.admin, &run_id, &period, &root, &open_reason);
+
+    let resolution_reason = Symbol::new(&ctx.env, "CORRECTED_AND_VERIFIED");
+    ctx.payroll_client
+        .resolve_dispute(&ctx.admin, &dispute_id, &resolution_reason);
+
+    let dispute = ctx.payroll_client.get_dispute(&dispute_id);
+    assert_eq!(dispute.status, DisputeStatus::Resolved);
+    assert_eq!(dispute.resolved_by, Some(ctx.admin.clone()));
+    assert_eq!(dispute.resolution_reason, Some(resolution_reason));
+    assert!(dispute.resolved_at.is_some());
+}
+
+// ── Authorization: only admin or a granted dispute authority may act ───────
+
+#[test]
+fn test_unauthorized_caller_cannot_open_dispute() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 9, 10_000i128);
+    let outsider = Address::generate(&ctx.env);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 9);
+    let reason = Symbol::new(&ctx.env, "DISCREPANCY");
+
+    let result = ctx
+        .payroll_client
+        .try_open_dispute(&outsider, &run_id, &period, &root, &reason);
+    assert!(
+        result.is_err(),
+        "Unauthorized caller must not be able to open a dispute"
+    );
+}
+
+#[test]
+fn test_unauthorized_caller_cannot_resolve_dispute() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 10, 10_000i128);
+    let outsider = Address::generate(&ctx.env);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 10);
+    let open_reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    let dispute_id =
+        ctx.payroll_client
+            .open_dispute(&ctx.admin, &run_id, &period, &root, &open_reason);
+
+    let resolution_reason = Symbol::new(&ctx.env, "VERIFIED_OK");
+    let result = ctx
+        .payroll_client
+        .try_resolve_dispute(&outsider, &dispute_id, &resolution_reason);
+    assert!(
+        result.is_err(),
+        "Unauthorized caller must not be able to resolve a dispute"
+    );
+
+    // The run must remain frozen since the resolution attempt failed.
+    assert!(ctx.payroll_client.is_run_disputed(&run_id));
+}
+
+#[test]
+fn test_granted_dispute_authority_can_open_and_resolve() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 11, 10_000i128);
+    let auditor = Address::generate(&ctx.env);
+
+    // Not yet authorized.
+    assert!(!ctx.payroll_client.is_dispute_authority(&auditor));
+
+    ctx.payroll_client
+        .add_dispute_authority(&ctx.admin, &auditor);
+    assert!(ctx.payroll_client.is_dispute_authority(&auditor));
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 11);
+    let open_reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    let dispute_id =
+        ctx.payroll_client
+            .open_dispute(&auditor, &run_id, &period, &root, &open_reason);
+
+    assert!(ctx.payroll_client.is_run_disputed(&run_id));
+
+    let resolution_reason = Symbol::new(&ctx.env, "VERIFIED_OK");
+    ctx.payroll_client
+        .resolve_dispute(&auditor, &dispute_id, &resolution_reason);
+
+    assert!(!ctx.payroll_client.is_run_disputed(&run_id));
+}
+
+#[test]
+fn test_removed_dispute_authority_cannot_open_dispute() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 12, 10_000i128);
+    let auditor = Address::generate(&ctx.env);
+
+    ctx.payroll_client
+        .add_dispute_authority(&ctx.admin, &auditor);
+    ctx.payroll_client
+        .remove_dispute_authority(&ctx.admin, &auditor);
+    assert!(!ctx.payroll_client.is_dispute_authority(&auditor));
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 12);
+    let reason = Symbol::new(&ctx.env, "DISCREPANCY");
+
+    let result = ctx
+        .payroll_client
+        .try_open_dispute(&auditor, &run_id, &period, &root, &reason);
+    assert!(
+        result.is_err(),
+        "A revoked dispute authority must not be able to open a dispute"
+    );
+}
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_cannot_open_duplicate_active_dispute_for_same_run() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 13, 10_000i128);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 13);
+    let reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    ctx.payroll_client
+        .open_dispute(&ctx.admin, &run_id, &period, &root, &reason);
+
+    let result = ctx
+        .payroll_client
+        .try_open_dispute(&ctx.admin, &run_id, &period, &root, &reason);
+    assert!(
+        result.is_err(),
+        "A run must not be able to have two simultaneous active disputes"
+    );
+}
+
+#[test]
+fn test_cannot_resolve_already_resolved_dispute() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 14, 10_000i128);
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 14);
+    let open_reason = Symbol::new(&ctx.env, "DISCREPANCY");
+    let dispute_id =
+        ctx.payroll_client
+            .open_dispute(&ctx.admin, &run_id, &period, &root, &open_reason);
+
+    let resolution_reason = Symbol::new(&ctx.env, "VERIFIED_OK");
+    ctx.payroll_client
+        .resolve_dispute(&ctx.admin, &dispute_id, &resolution_reason);
+
+    let result =
+        ctx.payroll_client
+            .try_resolve_dispute(&ctx.admin, &dispute_id, &resolution_reason);
+    assert!(
+        result.is_err(),
+        "Resolving an already-resolved dispute must fail"
+    );
+}
+
+#[test]
+fn test_cannot_open_dispute_for_nonexistent_run() {
+    let ctx = setup_test_context();
+
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 15);
+    let reason = Symbol::new(&ctx.env, "DISCREPANCY");
+
+    let result = ctx
+        .payroll_client
+        .try_open_dispute(&ctx.admin, &999u64, &period, &root, &reason);
+    assert!(
+        result.is_err(),
+        "Opening a dispute against a nonexistent run must fail"
+    );
+}
+
+#[test]
+fn test_dispute_can_be_opened_against_pending_run_before_finalization() {
+    let ctx = setup_test_context();
+    let run_id = prepare_run(&ctx, 16, 10_000i128);
+
+    // Run is still pending (not finalized) at this point.
+    let period = Symbol::new(&ctx.env, "PERIOD_2026_01");
+    let root = batch_root(&ctx.env, 16);
+    let reason = Symbol::new(&ctx.env, "PRE_FINALIZATION_HOLD");
+    let dispute_id = ctx
+        .payroll_client
+        .open_dispute(&ctx.admin, &run_id, &period, &root, &reason);
+
+    assert!(ctx.payroll_client.is_run_disputed(&run_id));
+    let dispute = ctx.payroll_client.get_dispute(&dispute_id);
+    assert_eq!(dispute.status, DisputeStatus::Active);
+}


### PR DESCRIPTION
Closes #342

## Summary

Adds on-chain dispute records that freeze irreversible payroll lifecycle actions (finalization, archival, and pruning) while a dispute is active, and allow an authorized party to thaw the run by resolving the dispute with a reason code.

## What's Implemented

- **Dispute records** scoped to employer (contract admin), period label, and batch root, stored with an auto-incrementing `dispute_id` and linked to the disputed `run_id`.
- **Freeze enforcement**: `finalize_payroll_run`, `archive_payroll_run`, and a new `prune_payroll_run` entry point all reject calls while the target run has an active dispute (`"Run is under active dispute"`).
- **Authorization**: only the contract admin, or an address explicitly granted the new dispute-authority role (`add_dispute_authority` / `remove_dispute_authority`), may open or resolve a dispute.
- **Thaw**: `resolve_dispute` marks a dispute `Resolved` with a resolution reason code, clears the freeze, and allows normal lifecycle actions to continue.
- **Pruning**: added `prune_payroll_run`, a new irreversible cleanup entry point (permanently removes an archived run's on-chain record) that only proceeds once the run has been archived and has no active dispute — matching the freeze guard applied to finalize/archive.
- **Events**: `dispute_opened`, `dispute_resolved`, `dispute_auth_added`, `dispute_auth_removed`, and `run_pruned` are emitted via the shared `payroll_events` crate for audit trails.

## New Files

- `tests/disputes/Cargo.toml` — new workspace test crate for dispute coverage.
- `tests/disputes/dispute_freeze.rs` — 16 integration tests (see below).

## Modified Files

- `contracts/payroll/src/lib.rs` — `Dispute` / `DisputeStatus` types, new `DataKey` variants (`DisputeCounter`, `Dispute(u64)`, `ActiveDisputeForRun(u64)`, `DisputeAuthority(Address)`), `open_dispute`, `resolve_dispute`, `get_dispute`, `is_run_disputed`, `add_dispute_authority`, `remove_dispute_authority`, `is_dispute_authority`, `prune_payroll_run`, and freeze guards added to `finalize_payroll_run` / `archive_payroll_run`.
- `contracts/events/src/lib.rs` — new event emitters for the dispute lifecycle and run pruning.
- `Cargo.toml` — registers the new `tests/disputes` workspace member.

## Implementation Details

- A dispute can be opened against a run that is either still pending (`PendingRun`) or already finalized (`PayrollRun`), so evidence can be preserved before or after execution.
- Only one active dispute may exist per run at a time (`ActiveDisputeForRun` storage key); opening a second dispute against an already-disputed run is rejected.
- The admin implicitly holds dispute authority; additional addresses (e.g. auditors, reviewers) can be granted or revoked the role independently, without changing their reviewer/admin permissions.
- `prune_payroll_run` is a new, intentionally irreversible entry point (there was no pruning path previously) that only operates on already-archived runs, so the freeze guard has a concrete lifecycle action to protect beyond finalize/archive.
- All new authorization and existence checks follow the codebase's existing `panic!`-based validation style (no new error enum was introduced, consistent with the rest of `payroll/src/lib.rs`).

## Tests Added (`tests/disputes/dispute_freeze.rs`)

**Freeze behavior**
- `test_active_dispute_blocks_finalization`
- `test_active_dispute_blocks_archival`
- `test_active_dispute_blocks_pruning`
- `test_pruning_requires_archived_run`

**Thaw behavior**
- `test_resolved_dispute_allows_finalization`
- `test_resolved_dispute_allows_archive_and_prune`
- `test_dispute_record_scoped_to_employer_period_and_batch_root`
- `test_resolve_dispute_records_resolver_and_reason`

**Authorization**
- `test_unauthorized_caller_cannot_open_dispute`
- `test_unauthorized_caller_cannot_resolve_dispute`
- `test_granted_dispute_authority_can_open_and_resolve`
- `test_removed_dispute_authority_cannot_open_dispute`

**Edge cases**
- `test_cannot_open_duplicate_active_dispute_for_same_run`
- `test_cannot_resolve_already_resolved_dispute`
- `test_cannot_open_dispute_for_nonexistent_run`
- `test_dispute_can_be_opened_against_pending_run_before_finalization`

All 16 tests pass locally via `cargo test -p dispute_tests`.

## How to Test

```bash
# Run the new dispute freeze/thaw test suite
cargo test -p dispute_tests

# Confirm no regressions in the payroll contract's own test suite
cargo test -p payroll

# Formatting / linting
cargo fmt --check
cargo clippy -p payroll -p payroll_events -p dispute_tests -- -D warnings
```