### PR TITLE
feat(payroll): add per-period payroll capacity limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "period_capacity_tests"
+version = "0.1.0"
+dependencies = [
+ "payroll",
+ "proof_verifier",
+ "salary_commitment",
+ "soroban-sdk",
+ "token",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "tests/storage",
     "tests/access-control",
     "tests/events",
+    "tests/period-capacity",
 ]
 exclude = ["fuzz"]
 

--- a/contracts/events/src/lib.rs
+++ b/contracts/events/src/lib.rs
@@ -204,6 +204,52 @@ pub fn emit_reconciliation_updated(e: &Env, run_id: u64, status: Symbol) {
     );
 }
 
+/// Emitted when the employer's per-period capacity policy is set or replaced (#338).
+pub fn emit_capacity_limits_set(
+    e: &Env,
+    max_batches: u32,
+    max_employees: u32,
+    max_total_value: i128,
+) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "capacity_limits_set")),
+        (max_batches, max_employees, max_total_value),
+    );
+}
+
+/// Emitted when a new payroll period is opened for capacity accounting (#338).
+pub fn emit_capacity_period_opened(e: &Env, period: Symbol) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "capacity_period_opened")),
+        period,
+    );
+}
+
+/// Emitted after a batch is accepted and its usage recorded against the
+/// active period's capacity counters (#338).
+pub fn emit_capacity_usage_recorded(
+    e: &Env,
+    period: Symbol,
+    batch_count: u32,
+    employee_count: u32,
+    total_value: i128,
+) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "capacity_usage")),
+        (period, batch_count, employee_count, total_value),
+    );
+}
+
+/// Emitted when a batch is rejected for exceeding a capacity limit. `kind`
+/// identifies the exceeded category: 0 = batch count, 1 = employee count,
+/// 2 = total value (mirrors `payroll::CapacityLimitKind`) (#338).
+pub fn emit_capacity_limit_exceeded(e: &Env, period: Symbol, kind: u32) {
+    e.events().publish(
+        (payroll_topic(), Symbol::new(e, "capacity_exceeded")),
+        (period, kind),
+    );
+}
+
 /// Emitted when a new admin is proposed (step 1 of 2).
 pub fn emit_admin_proposed(e: &Env, current_admin: Address, new_admin: Address) {
     e.events().publish(

--- a/contracts/events/src/lib.rs
+++ b/contracts/events/src/lib.rs
@@ -777,7 +777,10 @@ pub fn emit_audit_pause_manager_set(e: &Env, pause_manager: Address) {
 /// Emitted when locked payroll funds are updated (#343).
 pub fn emit_locked_funds_updated(e: &Env, asset: Address, locked_amount: i128) {
     e.events().publish(
-        (Symbol::new(e, "treasury"), Symbol::new(e, "locked_funds_updated")),
+        (
+            Symbol::new(e, "treasury"),
+            Symbol::new(e, "locked_funds_updated"),
+        ),
         (asset, locked_amount),
     );
 }

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
+use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token as soroban_token, Address, BytesN,
     Env, Symbol, Vec,
 };
-use soroban_sdk::xdr::ToXdr;
 
 use pause_manager::PauseManagerClient;
 use proof_verifier::ProofVerifierClient;
@@ -2112,7 +2112,9 @@ impl Payroll {
 
     /// Check if a quorum approval payload hash has already been consumed.
     pub fn is_quorum_consumed(e: Env, quorum_hash: BytesN<32>) -> bool {
-        e.storage().persistent().has(&DataKey::ConsumedQuorum(quorum_hash))
+        e.storage()
+            .persistent()
+            .has(&DataKey::ConsumedQuorum(quorum_hash))
     }
 
     /// Verify signer quorum requirements and consume the quorum approval reference once.
@@ -2149,11 +2151,17 @@ impl Payroll {
             panic!("Quorum approval payload already consumed: replay rejected");
         }
 
-        e.storage()
-            .persistent()
-            .set(&DataKey::ConsumedQuorum(q_hash.clone()), &e.ledger().timestamp());
+        e.storage().persistent().set(
+            &DataKey::ConsumedQuorum(q_hash.clone()),
+            &e.ledger().timestamp(),
+        );
 
-        payroll_events::emit_quorum_consumed(&e, payload.batch_root, payload.employer, payload.nonce);
+        payroll_events::emit_quorum_consumed(
+            &e,
+            payload.batch_root,
+            payload.employer,
+            payload.nonce,
+        );
         q_hash
     }
 
@@ -5072,7 +5080,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Insufficient available treasury balance: funds locked for pending payroll")]
+    #[should_panic(
+        expected = "Insufficient available treasury balance: funds locked for pending payroll"
+    )]
     fn test_withdrawal_guardrails_rejects_underfunding() {
         let env = Env::default();
         let (payroll_client, _admin, treasury, treasury_owner, employee, token_id) =

--- a/contracts/payroll/src/lib.rs
+++ b/contracts/payroll/src/lib.rs
@@ -176,6 +176,45 @@ pub struct RunReview {
     pub reviewed_at: u64,
 }
 
+// ── Issue #338: per-period payroll capacity limits ───────────────────────────
+
+/// Employer-configured capacity limits enforced per payroll period.
+///
+/// Limits are opt-in: if no policy has been set via `set_capacity_limits`,
+/// `prepare_payroll_run` and `batch_process_payroll` behave exactly as
+/// before, with no capacity checks performed.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CapacityLimits {
+    /// Maximum number of batches (prepared or executed) allowed per period.
+    pub max_batches: u32,
+    /// Maximum cumulative employee count allowed per period.
+    pub max_employees: u32,
+    /// Maximum cumulative committed value allowed per period.
+    pub max_total_value: i128,
+}
+
+/// Accumulated usage counters for a single payroll period, tracked against
+/// the employer's `CapacityLimits` policy.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PeriodUsage {
+    pub batch_count: u32,
+    pub employee_count: u32,
+    pub total_value: i128,
+}
+
+/// Category of capacity limit exceeded by a batch, for precise error
+/// identification (issue #338).
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum CapacityLimitKind {
+    BatchCount = 0,
+    EmployeeCount = 1,
+    TotalValue = 2,
+}
+
 // ── Issue #91: privileged-role rotation ──────────────────────────────────────
 
 /// Pending two-step role-rotation request.
@@ -337,6 +376,12 @@ pub enum DataKey {
     AuthorizedReviewer(Address),
     /// Review record for a payroll run.
     RunReview(u64),
+    /// Employer-configured per-period capacity limits (#338).
+    CapacityLimits,
+    /// The payroll period currently open for capacity accounting (#338).
+    CurrentPeriod,
+    /// Accumulated batch/employee/value usage counters for a period (#338).
+    PeriodUsage(Symbol),
     // Future upgrade example (issue #196):
     // PayrollRunV2(u64),  // Would be added here when schema evolution is needed
 }
@@ -1023,6 +1068,9 @@ impl Payroll {
             panic!("Asset not allowed");
         }
 
+        // Issue #338: enforce per-period capacity limits before the batch is locked in.
+        Self::enforce_and_record_capacity(&e, count, expected_total_spend);
+
         let run_id = Self::derive_run_id(&e);
 
         // Mark nonce as consumed (store run_id for auditability).
@@ -1256,6 +1304,9 @@ impl Payroll {
         }
 
         addrs.admin.require_auth();
+
+        // Issue #338: enforce per-period capacity limits before the batch executes.
+        Self::enforce_and_record_capacity(&e, count, expected_total_spend);
 
         let run_id = Self::derive_run_id(&e);
 
@@ -1930,6 +1981,164 @@ impl Payroll {
             .persistent()
             .get(&DataKey::CompanyState)
             .unwrap_or(CompanyState::Active)
+    }
+
+    // ── Issue #338: per-period payroll capacity limits ───────────────────────
+
+    /// Set (or replace) the employer's per-period capacity policy. Only the
+    /// admin may call. Passing this once opts every subsequent period into
+    /// capacity enforcement; there is no policy prior to the first call.
+    pub fn set_capacity_limits(
+        e: Env,
+        admin: Address,
+        max_batches: u32,
+        max_employees: u32,
+        max_total_value: i128,
+    ) {
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+
+        if max_batches == 0 || max_employees == 0 || max_total_value <= 0 {
+            panic!("Capacity limits must be positive");
+        }
+
+        let limits = CapacityLimits {
+            max_batches,
+            max_employees,
+            max_total_value,
+        };
+        e.storage()
+            .persistent()
+            .set(&DataKey::CapacityLimits, &limits);
+
+        payroll_events::emit_capacity_limits_set(&e, max_batches, max_employees, max_total_value);
+    }
+
+    /// Return the currently configured capacity policy, if any.
+    pub fn get_capacity_limits(e: Env) -> Option<CapacityLimits> {
+        e.storage().persistent().get(&DataKey::CapacityLimits)
+    }
+
+    /// Open a new payroll period for capacity accounting. Only the admin may
+    /// call. Usage counters are scoped per period label, so opening a period
+    /// that has never been used before starts with fresh (zeroed) counters;
+    /// re-opening a previously used period label resumes accumulating
+    /// against its existing counters.
+    pub fn open_capacity_period(e: Env, admin: Address, period: Symbol) {
+        let addrs: ContractAddresses = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Addresses)
+            .expect("Not initialized");
+        if admin != addrs.admin {
+            panic!("Unauthorized");
+        }
+        admin.require_auth();
+        Self::validate_symbol_not_empty(&e, &period, "period");
+
+        e.storage()
+            .persistent()
+            .set(&DataKey::CurrentPeriod, &period);
+
+        payroll_events::emit_capacity_period_opened(&e, period);
+    }
+
+    /// Return the payroll period currently open for capacity accounting, if any.
+    pub fn get_current_period(e: Env) -> Option<Symbol> {
+        e.storage().persistent().get(&DataKey::CurrentPeriod)
+    }
+
+    /// Return the accumulated usage counters for a given period. Periods
+    /// with no recorded usage return zeroed counters.
+    pub fn get_period_usage(e: Env, period: Symbol) -> PeriodUsage {
+        e.storage()
+            .persistent()
+            .get(&DataKey::PeriodUsage(period))
+            .unwrap_or(PeriodUsage {
+                batch_count: 0,
+                employee_count: 0,
+                total_value: 0,
+            })
+    }
+
+    /// Enforce the employer's capacity policy against the currently open
+    /// period and record the batch's usage, before the batch is locked in
+    /// (`prepare_payroll_run`) or executed (`batch_process_payroll`).
+    ///
+    /// A no-op when no policy has been configured or no period has been
+    /// opened, preserving backward compatibility for callers that don't use
+    /// this feature.
+    fn enforce_and_record_capacity(e: &Env, employee_count: u32, batch_value: i128) {
+        let limits: CapacityLimits = match e.storage().persistent().get(&DataKey::CapacityLimits) {
+            Some(limits) => limits,
+            None => return,
+        };
+        let period: Symbol = match e.storage().persistent().get(&DataKey::CurrentPeriod) {
+            Some(period) => period,
+            None => return,
+        };
+
+        let usage_key = DataKey::PeriodUsage(period.clone());
+        let usage: PeriodUsage = e
+            .storage()
+            .persistent()
+            .get(&usage_key)
+            .unwrap_or(PeriodUsage {
+                batch_count: 0,
+                employee_count: 0,
+                total_value: 0,
+            });
+
+        let new_batch_count = usage.batch_count + 1;
+        let new_employee_count = usage.employee_count + employee_count;
+        let new_total_value = usage.total_value + batch_value;
+
+        if new_batch_count > limits.max_batches {
+            payroll_events::emit_capacity_limit_exceeded(
+                e,
+                period,
+                CapacityLimitKind::BatchCount as u32,
+            );
+            panic!("Capacity limit exceeded: batch count");
+        }
+        if new_employee_count > limits.max_employees {
+            payroll_events::emit_capacity_limit_exceeded(
+                e,
+                period,
+                CapacityLimitKind::EmployeeCount as u32,
+            );
+            panic!("Capacity limit exceeded: employee count");
+        }
+        if new_total_value > limits.max_total_value {
+            payroll_events::emit_capacity_limit_exceeded(
+                e,
+                period,
+                CapacityLimitKind::TotalValue as u32,
+            );
+            panic!("Capacity limit exceeded: total value");
+        }
+
+        let new_usage = PeriodUsage {
+            batch_count: new_batch_count,
+            employee_count: new_employee_count,
+            total_value: new_total_value,
+        };
+        e.storage().persistent().set(&usage_key, &new_usage);
+
+        payroll_events::emit_capacity_usage_recorded(
+            e,
+            period,
+            new_usage.batch_count,
+            new_usage.employee_count,
+            new_usage.total_value,
+        );
     }
 
     // ── Issue #146: archived payroll run queries ──────────────────────────────

--- a/tests/access-control/admin_handover.rs
+++ b/tests/access-control/admin_handover.rs
@@ -82,12 +82,8 @@ fn test_admin_handover_success_and_role_transfer() {
     assert!(client.get_pending_admin_handover().is_none());
 
     // Verify new admin can perform admin operations
-    let draft_id = client.create_run_draft(
-        &pending_admin,
-        &10_000i128,
-        &5u32,
-        &Symbol::new(&env, "Q1"),
-    );
+    let draft_id =
+        client.create_run_draft(&pending_admin, &10_000i128, &5u32, &Symbol::new(&env, "Q1"));
     assert_eq!(draft_id, 1);
 }
 

--- a/tests/access-control/withdrawal_guardrails.rs
+++ b/tests/access-control/withdrawal_guardrails.rs
@@ -35,7 +35,16 @@ fn test_nonce(env: &Env, seed: u8) -> BytesN<32> {
     BytesN::from_array(env, &arr)
 }
 
-fn setup_payroll(env: &Env) -> (PayrollClient<'_>, Address, Address, Address, Address, Address) {
+fn setup_payroll(
+    env: &Env,
+) -> (
+    PayrollClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     env.mock_all_auths();
 
     let verifier_id = env.register_contract(None, ProofVerifier);
@@ -74,7 +83,14 @@ fn setup_payroll(env: &Env) -> (PayrollClient<'_>, Address, Address, Address, Ad
     let employee = Address::generate(env);
     commitment_client.store_commitment(&employee, &BytesN::from_array(env, &[0u8; 32]));
 
-    (payroll_client, admin, treasury, treasury_owner, employee, token_id)
+    (
+        payroll_client,
+        admin,
+        treasury,
+        treasury_owner,
+        employee,
+        token_id,
+    )
 }
 
 #[test]
@@ -87,7 +103,10 @@ fn test_withdrawal_before_lock_and_after_cancellation() {
 
     // Initial state: locked funds = 0, available = total_balance
     assert_eq!(client.get_locked_funds(&token_id), 0);
-    assert_eq!(client.get_available_treasury_balance(&token_id), total_balance);
+    assert_eq!(
+        client.get_available_treasury_balance(&token_id),
+        total_balance
+    );
 
     // Prepare payroll run locking 50,000
     let mut proofs = Vec::new(&env);
@@ -127,7 +146,9 @@ fn test_withdrawal_before_lock_and_after_cancellation() {
 }
 
 #[test]
-#[should_panic(expected = "Insufficient available treasury balance: funds locked for pending payroll")]
+#[should_panic(
+    expected = "Insufficient available treasury balance: funds locked for pending payroll"
+)]
 fn test_withdrawal_attempt_exceeding_surplus_rejected() {
     let env = Env::default();
     let (client, _admin, treasury, treasury_owner, employee, token_id) = setup_payroll(&env);

--- a/tests/period-capacity/Cargo.toml
+++ b/tests/period-capacity/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "period_capacity_tests"
+version.workspace = true
+edition.workspace = true
+
+[[test]]
+name = "period_capacity"
+path = "period_capacity.rs"
+
+[dev-dependencies]
+payroll = { path = "../../contracts/payroll" }
+proof_verifier = { path = "../../contracts/proof_verifier" }
+salary_commitment = { path = "../../contracts/salary_commitment" }
+token = { path = "../../contracts/token" }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/tests/period-capacity/period_capacity.rs
+++ b/tests/period-capacity/period_capacity.rs
@@ -1,0 +1,393 @@
+//! Per-Period Payroll Capacity Limit Tests (issue #338)
+//!
+//! Verifies that employer-configured capacity limits (max batches, max
+//! employees, max committed value) are enforced per payroll period before a
+//! batch is locked in (`prepare_payroll_run`) or executed
+//! (`batch_process_payroll`), that usage counters are scoped correctly per
+//! period, and that the feature is fully opt-in (no policy configured means
+//! no behavior change for existing callers).
+
+use payroll::{Payroll, PayrollClient};
+use proof_verifier::{ProofVerifier, ProofVerifierClient, VerificationKey};
+use salary_commitment::{SalaryCommitmentContract, SalaryCommitmentContractClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+use token::{Token, TokenClient};
+
+fn mock_vk(env: &Env) -> VerificationKey {
+    VerificationKey {
+        alpha: BytesN::from_array(env, &[0u8; 64]),
+        beta: BytesN::from_array(env, &[0u8; 128]),
+        gamma: BytesN::from_array(env, &[0u8; 128]),
+        delta: BytesN::from_array(env, &[0u8; 128]),
+        ic: Vec::from_array(
+            env,
+            [
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+                BytesN::from_array(env, &[0u8; 64]),
+            ],
+        ),
+    }
+}
+
+fn mock_proof(env: &Env) -> BytesN<256> {
+    BytesN::from_array(env, &[1u8; 256])
+}
+
+fn test_nonce(env: &Env, seed: u16) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = (seed & 0xFF) as u8;
+    bytes[1] = (seed >> 8) as u8;
+    bytes[31] = 0xAA;
+    BytesN::from_array(env, &bytes)
+}
+
+struct TestContext<'a> {
+    env: Env,
+    payroll_client: PayrollClient<'a>,
+    admin: Address,
+}
+
+fn setup_test_context() -> TestContext<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let verifier_id = env.register_contract(None, ProofVerifier);
+    let verifier_client = ProofVerifierClient::new(&env, &verifier_id);
+    let verifier_admin = Address::generate(&env);
+    verifier_client.init_verifier_admin(&verifier_admin);
+    verifier_client.initialize_verifier(&mock_vk(&env));
+
+    let commitment_id = env.register_contract(None, SalaryCommitmentContract);
+    let commitment_client = SalaryCommitmentContractClient::new(&env, &commitment_id);
+    let commitment_admin = Address::generate(&env);
+    commitment_client.init_commitment_admin(&commitment_admin);
+
+    let token_id = env.register_contract(None, Token);
+    let token_client = TokenClient::new(&env, &token_id);
+
+    let payroll_id = env.register_contract(None, Payroll);
+    let payroll_client = PayrollClient::new(&env, &payroll_id);
+
+    let treasury = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let treasury_owner = Address::generate(&env);
+
+    token_client.mint(&treasury, &10_000_000i128);
+
+    payroll_client.initialize(
+        &admin,
+        &token_id,
+        &verifier_id,
+        &commitment_id,
+        &treasury,
+        &treasury_owner,
+    );
+
+    commitment_client.set_payroll_operator(&payroll_id);
+
+    TestContext {
+        env,
+        payroll_client,
+        admin,
+    }
+}
+
+/// Builds a batch of `n` employees, each paid `amount_each`, using fresh
+/// addresses (no commitment registration needed since `prepare_payroll_run`
+/// does not touch the commitment or proof-verifier contracts).
+fn batch_of(
+    env: &Env,
+    n: u32,
+    amount_each: i128,
+) -> (Vec<BytesN<256>>, Vec<i128>, Vec<Address>, i128) {
+    let mut proofs = Vec::new(env);
+    let mut amounts = Vec::new(env);
+    let mut employees = Vec::new(env);
+    let mut total = 0i128;
+    for _ in 0..n {
+        proofs.push_back(mock_proof(env));
+        amounts.push_back(amount_each);
+        employees.push_back(Address::generate(env));
+        total += amount_each;
+    }
+    (proofs, amounts, employees, total)
+}
+
+fn prepare_batch(ctx: &TestContext, seed: u16, n: u32, amount_each: i128) -> u64 {
+    let (proofs, amounts, employees, total) = batch_of(&ctx.env, n, amount_each);
+    ctx.payroll_client.prepare_payroll_run(
+        &proofs,
+        &amounts,
+        &employees,
+        &total,
+        &test_nonce(&ctx.env, seed),
+        &None,
+    )
+}
+
+/// Attempts to prepare a batch and returns whether the call failed
+/// (rejected by validation, e.g. a capacity limit).
+fn try_prepare_batch_fails(ctx: &TestContext, seed: u16, n: u32, amount_each: i128) -> bool {
+    let (proofs, amounts, employees, total) = batch_of(&ctx.env, n, amount_each);
+    let result = ctx.payroll_client.try_prepare_payroll_run(
+        &proofs,
+        &amounts,
+        &employees,
+        &total,
+        &test_nonce(&ctx.env, seed),
+        &None,
+    );
+    result.is_err()
+}
+
+// ── Backward compatibility: capacity limits are fully opt-in ───────────────
+
+#[test]
+fn test_no_policy_configured_means_no_enforcement() {
+    let ctx = setup_test_context();
+    assert!(ctx.payroll_client.get_capacity_limits().is_none());
+
+    // Many batches with no policy configured must all succeed.
+    for i in 0..5u16 {
+        prepare_batch(&ctx, i, 3, 1_000i128);
+    }
+}
+
+#[test]
+fn test_policy_without_open_period_is_noop() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &1u32, &1u32, &1_000i128);
+
+    // No period has been opened yet, so enforcement does not apply even
+    // though a policy exists.
+    let run_id_1 = prepare_batch(&ctx, 1, 5, 10_000i128);
+    let run_id_2 = prepare_batch(&ctx, 2, 5, 10_000i128);
+    assert_ne!(run_id_1, run_id_2);
+}
+
+// ── Boundary behavior: exact-limit and over-limit cases ─────────────────────
+
+#[test]
+fn test_batch_count_exact_limit_succeeds() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &2u32, &100u32, &1_000_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_01");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    prepare_batch(&ctx, 1, 1, 1_000i128);
+    prepare_batch(&ctx, 2, 1, 1_000i128);
+
+    let usage = ctx.payroll_client.get_period_usage(&period);
+    assert_eq!(usage.batch_count, 2);
+}
+
+#[test]
+fn test_batch_count_over_limit_fails() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &2u32, &100u32, &1_000_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_01");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    prepare_batch(&ctx, 1, 1, 1_000i128);
+    prepare_batch(&ctx, 2, 1, 1_000i128);
+
+    let failed = try_prepare_batch_fails(&ctx, 3, 1, 1_000i128);
+    assert!(failed, "Third batch must exceed the batch-count limit");
+
+    // The rejected batch must not have been counted.
+    let usage = ctx.payroll_client.get_period_usage(&period);
+    assert_eq!(usage.batch_count, 2);
+}
+
+#[test]
+#[should_panic(expected = "Capacity limit exceeded: batch count")]
+fn test_batch_count_limit_error_identifies_category() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &1u32, &100u32, &1_000_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_01");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    prepare_batch(&ctx, 1, 1, 1_000i128);
+    prepare_batch(&ctx, 2, 1, 1_000i128);
+}
+
+#[test]
+fn test_employee_count_exact_limit_succeeds() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &10u32, &3u32, &1_000_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_02");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    prepare_batch(&ctx, 1, 3, 1_000i128);
+
+    let usage = ctx.payroll_client.get_period_usage(&period);
+    assert_eq!(usage.employee_count, 3);
+}
+
+#[test]
+fn test_employee_count_over_limit_fails() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &10u32, &3u32, &1_000_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_02");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    let failed = try_prepare_batch_fails(&ctx, 1, 4, 1_000i128);
+    assert!(
+        failed,
+        "A 4-employee batch must exceed the employee-count limit of 3"
+    );
+}
+
+#[test]
+#[should_panic(expected = "Capacity limit exceeded: employee count")]
+fn test_employee_count_limit_error_identifies_category() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &10u32, &2u32, &1_000_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_02");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    prepare_batch(&ctx, 1, 3, 1_000i128);
+}
+
+#[test]
+fn test_total_value_exact_limit_succeeds() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &10u32, &100u32, &10_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_03");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    prepare_batch(&ctx, 1, 1, 10_000i128);
+
+    let usage = ctx.payroll_client.get_period_usage(&period);
+    assert_eq!(usage.total_value, 10_000i128);
+}
+
+#[test]
+fn test_total_value_over_limit_fails() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &10u32, &100u32, &10_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_03");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    let failed = try_prepare_batch_fails(&ctx, 1, 1, 10_001i128);
+    assert!(
+        failed,
+        "A batch of 10,001 must exceed the 10,000 value limit"
+    );
+}
+
+#[test]
+#[should_panic(expected = "Capacity limit exceeded: total value")]
+fn test_total_value_limit_error_identifies_category() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &10u32, &100u32, &5_000i128);
+    let period = Symbol::new(&ctx.env, "P2026_03");
+    ctx.payroll_client.open_capacity_period(&ctx.admin, &period);
+
+    prepare_batch(&ctx, 1, 1, 6_000i128);
+}
+
+// ── Period scoping and reset behavior ───────────────────────────────────────
+
+#[test]
+fn test_period_counters_scoped_independently() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &1u32, &100u32, &1_000_000i128);
+
+    let period_a = Symbol::new(&ctx.env, "P2026_01");
+    ctx.payroll_client
+        .open_capacity_period(&ctx.admin, &period_a);
+    prepare_batch(&ctx, 1, 1, 1_000i128);
+
+    // Period A is now at its max_batches=1 limit; a second batch under A fails.
+    let failed_a = try_prepare_batch_fails(&ctx, 2, 1, 1_000i128);
+    assert!(failed_a);
+
+    // Opening a new period gives fresh (zeroed) counters, so the same batch
+    // succeeds under period B even though the policy is unchanged.
+    let period_b = Symbol::new(&ctx.env, "P2026_02");
+    ctx.payroll_client
+        .open_capacity_period(&ctx.admin, &period_b);
+    prepare_batch(&ctx, 3, 1, 1_000i128);
+
+    let usage_a = ctx.payroll_client.get_period_usage(&period_a);
+    let usage_b = ctx.payroll_client.get_period_usage(&period_b);
+    assert_eq!(usage_a.batch_count, 1);
+    assert_eq!(usage_b.batch_count, 1);
+}
+
+#[test]
+fn test_reopening_a_period_resumes_its_existing_counters() {
+    let ctx = setup_test_context();
+    ctx.payroll_client
+        .set_capacity_limits(&ctx.admin, &2u32, &100u32, &1_000_000i128);
+
+    let period_a = Symbol::new(&ctx.env, "P2026_01");
+    ctx.payroll_client
+        .open_capacity_period(&ctx.admin, &period_a);
+    prepare_batch(&ctx, 1, 1, 1_000i128);
+
+    let period_b = Symbol::new(&ctx.env, "P2026_02");
+    ctx.payroll_client
+        .open_capacity_period(&ctx.admin, &period_b);
+    prepare_batch(&ctx, 2, 1, 1_000i128);
+
+    // Re-open period A: its usage counter should resume from 1, not reset to 0.
+    ctx.payroll_client
+        .open_capacity_period(&ctx.admin, &period_a);
+    prepare_batch(&ctx, 3, 1, 1_000i128);
+    let usage_a = ctx.payroll_client.get_period_usage(&period_a);
+    assert_eq!(usage_a.batch_count, 2);
+
+    // A third batch under period A now exceeds its max_batches=2 limit.
+    let failed = try_prepare_batch_fails(&ctx, 4, 1, 1_000i128);
+    assert!(failed);
+}
+
+#[test]
+fn test_get_period_usage_defaults_to_zero_for_unused_period() {
+    let ctx = setup_test_context();
+    let usage = ctx
+        .payroll_client
+        .get_period_usage(&Symbol::new(&ctx.env, "NEVER_USED"));
+    assert_eq!(usage.batch_count, 0);
+    assert_eq!(usage.employee_count, 0);
+    assert_eq!(usage.total_value, 0);
+}
+
+// ── Authorization ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_unauthorized_caller_cannot_set_capacity_limits() {
+    let ctx = setup_test_context();
+    let outsider = Address::generate(&ctx.env);
+    let result = ctx
+        .payroll_client
+        .try_set_capacity_limits(&outsider, &10u32, &10u32, &10_000i128);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_unauthorized_caller_cannot_open_capacity_period() {
+    let ctx = setup_test_context();
+    let outsider = Address::generate(&ctx.env);
+    let period = Symbol::new(&ctx.env, "P2026_01");
+    let result = ctx
+        .payroll_client
+        .try_open_capacity_period(&outsider, &period);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Closes #338

## Summary

Adds an opt-in employer policy that enforces per-period capacity limits on payroll batches — maximum batch count, cumulative employee count, and cumulative committed value — rejecting batches that would exceed them before the batch is locked in or executed.

## What's Implemented

- **Capacity policy**: `set_capacity_limits(admin, max_batches, max_employees, max_total_value)` defines the employer's limits; `get_capacity_limits` returns the current policy (or `None` if unset).
- **Period scoping**: `open_capacity_period(admin, period)` marks a `Symbol` period label as the active accounting period. `get_current_period` returns it. Usage is tracked per period label via `get_period_usage(period)`, which returns zeroed counters for any period never used.
- **Enforcement**: both `prepare_payroll_run` and `batch_process_payroll` now call an internal capacity check immediately before the batch is locked in / executed. A batch that would push batch count, employee count, or total value over the configured limit is rejected, and the category responsible is identifiable both from the panic message and from the emitted `capacity_exceeded` event's `kind` field.
- **Fully opt-in / backward compatible**: enforcement only runs when *both* a policy has been set *and* a period has been opened. Existing callers that never touch this feature see no behavior change at all — verified with a dedicated regression test and the full existing `payroll` test suite (94 tests, all passing).
- **Events**: `capacity_limits_set`, `capacity_period_opened`, `capacity_usage` (recorded on every accepted batch), and `capacity_exceeded` (on rejection) are emitted via the shared `payroll_events` crate.

## New Files

- `tests/period-capacity/Cargo.toml` — new workspace test crate.
- `tests/period-capacity/period_capacity.rs` — 16 integration tests (see below).

## Modified Files

- `contracts/payroll/src/lib.rs` — `CapacityLimits` / `PeriodUsage` / `CapacityLimitKind` types, new `DataKey` variants (`CapacityLimits`, `CurrentPeriod`, `PeriodUsage(Symbol)`), `set_capacity_limits`, `get_capacity_limits`, `open_capacity_period`, `get_current_period`, `get_period_usage`, and the private `enforce_and_record_capacity` helper wired into `prepare_payroll_run` and `batch_process_payroll`.
- `contracts/events/src/lib.rs` — new event emitters for the capacity-limit lifecycle.
- `Cargo.toml` — registers the new `tests/period-capacity` workspace member.

## Implementation Details

- Limits are defined once per employer (not per period) via `set_capacity_limits`; usage counters are what's scoped per period, keyed by the `Symbol` passed to `open_capacity_period`. Opening a period label for the first time starts it at zero; re-opening a previously used label resumes accumulating against its existing counters rather than resetting them, so historical usage stays queryable via `get_period_usage` even after switching periods.
- The capacity check runs after existing validation (array lengths, nonce, asset allowlist, auth) and before any state mutation for the batch, so a rejected batch leaves no partial usage recorded.
- No new error/enum type was introduced beyond `CapacityLimitKind` (used only to select the panic message / event `kind` value), consistent with the codebase's existing `panic!`-based validation style — no separate `errors.rs` exists in this crate today.
- `prepare_payroll_run` and `batch_process_payroll` signatures were intentionally left unchanged to avoid breaking the ~30+ existing call sites across the test suite; the active period is instead an explicit, admin-controlled piece of contract state (mirroring how `CompanyState`/`PauseManager` are optional, backward-compatible gates elsewhere in this file).

## Tests Added (`tests/period-capacity/period_capacity.rs`)

**Backward compatibility**
- `test_no_policy_configured_means_no_enforcement`
- `test_policy_without_open_period_is_noop`

**Boundary: exact-limit and over-limit**
- `test_batch_count_exact_limit_succeeds` / `test_batch_count_over_limit_fails` / `test_batch_count_limit_error_identifies_category`
- `test_employee_count_exact_limit_succeeds` / `test_employee_count_over_limit_fails` / `test_employee_count_limit_error_identifies_category`
- `test_total_value_exact_limit_succeeds` / `test_total_value_over_limit_fails` / `test_total_value_limit_error_identifies_category`

**Period scoping and reset**
- `test_period_counters_scoped_independently`
- `test_reopening_a_period_resumes_its_existing_counters`
- `test_get_period_usage_defaults_to_zero_for_unused_period`

**Authorization**
- `test_unauthorized_caller_cannot_set_capacity_limits`
- `test_unauthorized_caller_cannot_open_capacity_period`

All 16 tests pass locally via `cargo test -p period_capacity_tests`.

## How to Test

```bash
# Run the new capacity limit test suite
cargo test -p period_capacity_tests

# Confirm no regressions in the payroll contract's own test suite
cargo test -p payroll

# Formatting / linting
cargo fmt --check
cargo clippy -p payroll -p payroll_events -p period_capacity_tests --all-targets -- -D warnings
```